### PR TITLE
Siphash-2-4 (32-bit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ polyfill without additional code changes.
 - [x] Public-key authenticated encryption (`crypto_box`)
 - [x] Secret-key authenticated encryption (`crypto_secretbox`)
 - [x] Anonymous public-key encryption (`crypto_box_seal`)
-- [ ] SipHash: fast collision-resistant hashing (`crypto_shorthash`)
+- [x] SipHash: fast collision-resistant hashing (`crypto_shorthash`)
 - [ ] HMAC-SHA-512/256: Secret-key message authentication (`crypto_auth`)
 - [x] BLAKE2b: Cryptographic hashing (`crypto_generichash`)
 - [ ] Argon2i: Password hashing / key derivation (`crypto_pwhash`)

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -401,7 +401,7 @@ class ParagonIE_Sodium_Compat
      */
     public static function crypto_secretbox_open($ciphertext, $nonce, $key)
     {
-        if (self::use_fallback('memcmp')) {
+        if (self::use_fallback('crypto_secretbox_open')) {
             return call_user_func_array(
                 '\\Sodium\\crypto_secretbox_open',
                 array($ciphertext, $nonce, $key)
@@ -418,7 +418,29 @@ class ParagonIE_Sodium_Compat
      */
     public static function crypto_stream($len, $nonce, $key)
     {
+        if (self::use_fallback('crypto_stream')) {
+            return call_user_func_array(
+                '\\Sodium\\crypto_stream',
+                array($len, $nonce, $key)
+            );
+        }
         return ParagonIE_Sodium_Core_Xsalsa20::xsalsa20($len, $nonce, $key);
+    }
+
+    /**
+     * @param string $message
+     * @param string $key
+     * @return string
+     */
+    public static function crypto_shorthash($message, $key)
+    {
+        if (self::use_fallback('crypto_shorthash')) {
+            return call_user_func_array(
+                '\\Sodium\\crypto_shorthash',
+                array($message, $key)
+            );
+        }
+        return ParagonIE_Sodium_Core_SipHash::sipHash24($message, $key);
     }
 
     /**

--- a/src/Core/SipHash.php
+++ b/src/Core/SipHash.php
@@ -1,0 +1,275 @@
+<?php
+
+/**
+ * Class ParagonIE_SodiumCompat_Core_SipHash
+ */
+class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
+{
+    /**
+     * @param int[] $v
+     * @return int[]
+     */
+    public static function sipRound(array $v)
+    {
+        # v0 += v1;
+        list($v[0], $v[1]) = self::add(
+            array_slice($v, 0, 2),
+            array_slice($v, 2, 2)
+        );
+        #  v1=ROTL(v1,13);
+        list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 13);
+        #  v1 ^= v0;
+        $v[2] ^= $v[0];
+        $v[3] ^= $v[1];
+        #  v0=ROTL(v0,32);
+        list($v[0], $v[1]) = self::rotl_64($v[0], $v[1], 32);
+
+        # v2 += v3;
+        list($v[4], $v[5]) = self::add(
+            array_slice($v, 4, 2),
+            array_slice($v, 6, 2)
+        );
+        # v3=ROTL(v3,16);
+        list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 16);
+        #  v3 ^= v2;
+        $v[6] ^= $v[4];
+        $v[7] ^= $v[5];
+
+        # v0 += v3;
+        list($v[0], $v[1]) = self::add(
+            array_slice($v, 0, 2),
+            array_slice($v, 6, 2)
+        );
+        # v3=ROTL(v3,21);
+        list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 21);
+        # v3 ^= v0;
+        $v[6] ^= $v[0];
+        $v[7] ^= $v[1];
+
+        # v2 += v1;
+        list($v[4], $v[5]) = self::add(
+            array_slice($v, 4, 2),
+            array_slice($v, 2, 2)
+        );
+        # v1=ROTL(v1,17);
+        list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 17);
+        #  v1 ^= v2;;
+        $v[2] ^= $v[4];
+        $v[3] ^= $v[5];
+        # v2=ROTL(v2,32)
+        list($v[4], $v[5]) = self::rotl_64($v[4], $v[5], 32);
+
+        return $v;
+    }
+
+    /**
+     * Add two 32 bit integers representing a 64-bit integer.
+     *
+     * @param int[] $a
+     * @param int[] $b
+     * @return int[]
+     */
+    public static function add(array $a, array $b)
+    {
+        $x1 = $a[1] + $b[1];
+        $c = $x1 >> 32; // Carry if ($a + $b) > 0xffffffff
+        $x0 = $a[0] + $b[0] + $c;
+        return array(
+            $x0 & 0xffffffff,
+            $x1 & 0xffffffff
+        );
+    }
+
+    /**
+     * @param int $int0
+     * @param int $int1
+     * @param int $c
+     * @return int[]
+     */
+    public static function rotl_64($int0, $int1, $c)
+    {
+        $int0 &= 0xffffffff;
+        $int1 &= 0xffffffff;
+        $c &= 63;
+        if ($c === 32) {
+            return array($int1, $int0);
+        }
+        if ($c > 31) {
+            $tmp = $int1;
+            $int1 = $int0;
+            $int0 = $tmp;
+            $c &= 31;
+        }
+        if ($c === 0) {
+            return array($int0, $int1);
+        }
+        return array(
+            0xffffffff & (
+                ($int0 << $c)
+                    |
+                ($int1 >> (32 - $c))
+            ),
+            0xffffffff & (
+                ($int1 << $c)
+                    |
+                ($int0 >> (32 - $c))
+            ),
+        );
+    }
+
+    /**
+     * Implements Siphash-2-4 using only 32-bit numbers.
+     *
+     * When we split an int into two, the higher bits go to the lower index.
+     * e.g. 0xDEADBEEFAB10C92D becomes [
+     *     0 => 0xDEADBEEF,
+     *     1 => 0xAB10C92D
+     * ].
+     *
+     * @param string $in
+     * @param string $key
+     * @return string
+     */
+    public static function sipHash24($in, $key)
+    {
+        $inlen = self::strlen($in);
+
+        # /* "somepseudorandomlygeneratedbytes" */
+        # u64 v0 = 0x736f6d6570736575ULL;
+        # u64 v1 = 0x646f72616e646f6dULL;
+        # u64 v2 = 0x6c7967656e657261ULL;
+        # u64 v3 = 0x7465646279746573ULL;
+        $v = array(
+            0x736f6d65, // 0
+            0x70736575, // 1
+            0x646f7261, // 2
+            0x6e646f6d, // 3
+            0x6c796765, // 4
+            0x6e657261, // 5
+            0x74656462, // 6
+            0x79746573  // 7
+        );
+        // v0 => $v[0], $v[1]
+        // v1 => $v[2], $v[3]
+        // v2 => $v[4], $v[5]
+        // v3 => $v[6], $v[7]
+
+        # u64 k0 = LOAD64_LE( k );
+        # u64 k1 = LOAD64_LE( k + 8 );
+        $k = array(
+            self::load_4(self::substr($key, 0, 4)),
+            self::load_4(self::substr($key, 4, 4)),
+            self::load_4(self::substr($key, 8, 4)),
+            self::load_4(self::substr($key, 12, 4))
+        );
+        // k0 => $k[0], $k[1]
+        // k1 => $k[2], $k[3]
+
+        # b = ( ( u64 )inlen ) << 56;
+        $b = array(
+            $inlen << 24,
+            0
+        );
+        // See docblock for why the 0th index gets the higher bits.
+
+        # v3 ^= k1;
+        $v[6] ^= $k[2];
+        $v[7] ^= $k[3];
+        # v2 ^= k0;
+        $v[4] ^= $k[0];
+        $v[5] ^= $k[1];
+        # v1 ^= k1;
+        $v[2] ^= $k[2];
+        $v[3] ^= $k[3];
+        # v0 ^= k0;
+        $v[0] ^= $k[0];
+        $v[1] ^= $k[1];
+
+        $left = $inlen;
+        # for ( ; in != end; in += 8 )
+        while ($left >= 8) {
+            # m = LOAD64_LE( in );
+            $m = array(
+                self::load_4(self::substr($in, 0, 4)),
+                self::load_4(self::substr($in, 4, 4))
+            );
+
+            # v3 ^= m;
+            $v[6] ^= $m[0];
+            $v[7] ^= $m[1];
+
+            # SIPROUND;
+            # SIPROUND;
+            $v = self::sipRound($v);
+            $v = self::sipRound($v);
+
+            # v0 ^= m;
+            $v[0] ^= $m[0];
+            $v[1] ^= $m[1];
+
+            $in = self::substr($in, 8);
+            $left -= 8;
+        }
+
+        # switch( left )
+        #  {
+        #     case 7: b |= ( ( u64 )in[ 6] )  << 48;
+        #     case 6: b |= ( ( u64 )in[ 5] )  << 40;
+        #     case 5: b |= ( ( u64 )in[ 4] )  << 32;
+        #     case 4: b |= ( ( u64 )in[ 3] )  << 24;
+        #     case 3: b |= ( ( u64 )in[ 2] )  << 16;
+        #     case 2: b |= ( ( u64 )in[ 1] )  <<  8;
+        #     case 1: b |= ( ( u64 )in[ 0] ); break;
+        #     case 0: break;
+        # }
+        switch ($left) {
+            case 7:
+                $b[0] |= self::chrToInt($in[6]) << 16;
+            case 6:
+                $b[0] |= self::chrToInt($in[5]) << 8;
+            case 5:
+                $b[0] |= self::chrToInt($in[4]);
+            case 4:
+                $b[1] |= self::chrToInt($in[3]) << 24;
+            case 3:
+                $b[1] |= self::chrToInt($in[2]) << 16;
+            case 2:
+                $b[1] |= self::chrToInt($in[1]) << 8;
+            case 1:
+                $b[1] |= self::chrToInt($in[0]);
+            case 0:
+                break;
+        }
+        // See docblock for why the 0th index gets the higher bits.
+
+        # v3 ^= b;
+        $v[6] ^= $b[0];
+        $v[7] ^= $b[1];
+
+        # SIPROUND;
+        # SIPROUND;
+        $v = self::sipRound($v);
+        $v = self::sipRound($v);
+
+        # v0 ^= b;
+        $v[0] ^= $b[0];
+        $v[1] ^= $b[1];
+
+        # v2 ^= 0xff;
+        $v[3] ^= 0xff;
+
+        # SIPROUND;
+        # SIPROUND;
+        # SIPROUND;
+        # SIPROUND;
+        $v = self::sipRound($v);
+        $v = self::sipRound($v);
+        $v = self::sipRound($v);
+        $v = self::sipRound($v);
+
+        # b = v0 ^ v1 ^ v2 ^ v3;
+        # STORE64_LE( out, b );
+        return self::store32_le($v[0] ^ $v[2] ^ $v[4] ^ $v[6]) .
+            self::store32_le($v[1] ^ $v[3] ^ $v[5] ^ $v[7]);
+    }
+}

--- a/src/Core/SipHash.php
+++ b/src/Core/SipHash.php
@@ -16,11 +16,14 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
             array($v[0], $v[1]),
             array($v[2], $v[3])
         );
+
         #  v1=ROTL(v1,13);
         list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 13);
+
         #  v1 ^= v0;
         $v[2] ^= $v[0];
         $v[3] ^= $v[1];
+
         #  v0=ROTL(v0,32);
         list($v[0], $v[1]) = self::rotl_64($v[0], $v[1], 32);
 
@@ -29,8 +32,10 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
             array($v[4], $v[5]),
             array($v[6], $v[7])
         );
+
         # v3=ROTL(v3,16);
         list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 16);
+
         #  v3 ^= v2;
         $v[6] ^= $v[4];
         $v[7] ^= $v[5];
@@ -40,8 +45,10 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
             array($v[0], $v[1]),
             array($v[6], $v[7])
         );
+
         # v3=ROTL(v3,21);
         list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 21);
+
         # v3 ^= v0;
         $v[6] ^= $v[0];
         $v[7] ^= $v[1];
@@ -51,11 +58,14 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
             array($v[4], $v[5]),
             array($v[2], $v[3])
         );
+
         # v1=ROTL(v1,17);
         list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 17);
+
         #  v1 ^= v2;;
         $v[2] ^= $v[4];
         $v[3] ^= $v[5];
+
         # v2=ROTL(v2,32)
         list($v[4], $v[5]) = self::rotl_64($v[4], $v[5], 32);
 
@@ -157,10 +167,10 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
         # u64 k0 = LOAD64_LE( k );
         # u64 k1 = LOAD64_LE( k + 8 );
         $k = array(
-            self::load_4(self::substr($key, 0, 4)),
             self::load_4(self::substr($key, 4, 4)),
-            self::load_4(self::substr($key, 8, 4)),
-            self::load_4(self::substr($key, 12, 4))
+            self::load_4(self::substr($key, 0, 4)),
+            self::load_4(self::substr($key, 12, 4)),
+            self::load_4(self::substr($key, 8, 4))
         );
         // k0 => $k[0], $k[1]
         // k1 => $k[2], $k[3]
@@ -190,8 +200,8 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
         while ($left >= 8) {
             # m = LOAD64_LE( in );
             $m = array(
-                self::load_4(self::substr($in, 0, 4)),
-                self::load_4(self::substr($in, 4, 4))
+                self::load_4(self::substr($in, 4, 4)),
+                self::load_4(self::substr($in, 0, 4))
             );
 
             # v3 ^= m;
@@ -270,7 +280,7 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
 
         # b = v0 ^ v1 ^ v2 ^ v3;
         # STORE64_LE( out, b );
-        return self::store32_le($v[0] ^ $v[2] ^ $v[4] ^ $v[6]) .
-            self::store32_le($v[1] ^ $v[3] ^ $v[5] ^ $v[7]);
+        return  self::store32_le($v[1] ^ $v[3] ^ $v[5] ^ $v[7]) .
+            self::store32_le($v[0] ^ $v[2] ^ $v[4] ^ $v[6]);
     }
 }

--- a/src/Core/SipHash.php
+++ b/src/Core/SipHash.php
@@ -13,8 +13,8 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
     {
         # v0 += v1;
         list($v[0], $v[1]) = self::add(
-            array_slice($v, 0, 2),
-            array_slice($v, 2, 2)
+            array($v[0], $v[1]),
+            array($v[2], $v[3])
         );
         #  v1=ROTL(v1,13);
         list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 13);
@@ -26,8 +26,8 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
 
         # v2 += v3;
         list($v[4], $v[5]) = self::add(
-            array_slice($v, 4, 2),
-            array_slice($v, 6, 2)
+            array($v[4], $v[5]),
+            array($v[6], $v[7])
         );
         # v3=ROTL(v3,16);
         list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 16);
@@ -37,8 +37,8 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
 
         # v0 += v3;
         list($v[0], $v[1]) = self::add(
-            array_slice($v, 0, 2),
-            array_slice($v, 6, 2)
+            array($v[0], $v[1]),
+            array($v[6], $v[7])
         );
         # v3=ROTL(v3,21);
         list($v[6], $v[7]) = self::rotl_64($v[6], $v[7], 21);
@@ -48,8 +48,8 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
 
         # v2 += v1;
         list($v[4], $v[5]) = self::add(
-            array_slice($v, 4, 2),
-            array_slice($v, 2, 2)
+            array($v[4], $v[5]),
+            array($v[2], $v[3])
         );
         # v1=ROTL(v1,17);
         list($v[2], $v[3]) = self::rotl_64($v[2], $v[3], 17);
@@ -255,8 +255,9 @@ class ParagonIE_Sodium_Core_SipHash extends ParagonIE_Sodium_Core_Util
         $v[0] ^= $b[0];
         $v[1] ^= $b[1];
 
+        // Flip the lower 8 bits of v2 which is ($v[4], $v[5]) in our implementation
         # v2 ^= 0xff;
-        $v[3] ^= 0xff;
+        $v[5] ^= 0xff;
 
         # SIPROUND;
         # SIPROUND;

--- a/tests/compat/SodiumCompatTest.php
+++ b/tests/compat/SodiumCompatTest.php
@@ -570,4 +570,18 @@ class SodiumCompatTest extends PHPUnit_Framework_TestCase
             'crypto_stream_xor() is not working'
         );
     }
+
+    /**
+     *
+     */
+    public function testCryptoShorthash()
+    {
+        $message = 'predictable input';
+        $key = random_bytes(16);
+
+        $this->assertSame(
+            bin2hex(\Sodium\crypto_shorthash($message, $key)),
+            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
+        );
+    }
 }

--- a/tests/compat/SodiumCompatTest.php
+++ b/tests/compat/SodiumCompatTest.php
@@ -583,5 +583,11 @@ class SodiumCompatTest extends PHPUnit_Framework_TestCase
             bin2hex(\Sodium\crypto_shorthash($message, $key)),
             bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
         );
+
+        $message = random_bytes(random_int(1, 100));
+        $this->assertSame(
+            bin2hex(\Sodium\crypto_shorthash($message, $key)),
+            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
+        );
     }
 }

--- a/tests/compat/SodiumCompatTest.php
+++ b/tests/compat/SodiumCompatTest.php
@@ -576,18 +576,36 @@ class SodiumCompatTest extends PHPUnit_Framework_TestCase
      */
     public function testCryptoShorthash()
     {
-        $message = 'predictable input';
+        $message = str_repeat("\x00", 8);
+        $key = str_repeat("\x00", 16);
+        $this->shorthashVerify($message, $key);
+
+        $key = str_repeat("\xff", 16);
+        $this->shorthashVerify($message, $key);
+
+        $message = str_repeat("\x01", 8);
+        $this->shorthashVerify($message, $key);
+
+        $message = str_repeat("\x01", 7) . "\x02";
+        $this->shorthashVerify($message, $key);
+
+        $key = str_repeat("\xff", 8) . str_repeat("\x00", 8);
+        $this->shorthashVerify($message, $key);
+
+        $message = str_repeat("\x00", 8);
         $key = random_bytes(16);
 
-        $this->assertSame(
-            bin2hex(\Sodium\crypto_shorthash($message, $key)),
-            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
-        );
+        $this->shorthashVerify($message, $key);
 
         $message = random_bytes(random_int(1, 100));
+        $this->shorthashVerify($message, $key);
+    }
+    
+    protected function shorthashVerify($m, $k)
+    {
         $this->assertSame(
-            bin2hex(\Sodium\crypto_shorthash($message, $key)),
-            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
+            bin2hex(\Sodium\crypto_shorthash($m, $k)),
+            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($m, $k))
         );
     }
 }

--- a/tests/unit/Blake2bTest.php
+++ b/tests/unit/Blake2bTest.php
@@ -2,6 +2,11 @@
 
 class Blake2bTest extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        ParagonIE_Sodium_Compat::$disableFallbackForUnitTests = true;
+    }
+
     /**
      * @covers ParagonIE_Sodium_Compat::crypto_generichash()
      */

--- a/tests/unit/Poly1305Test.php
+++ b/tests/unit/Poly1305Test.php
@@ -2,6 +2,11 @@
 
 class Poly1305Test extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        ParagonIE_Sodium_Compat::$disableFallbackForUnitTests = true;
+    }
+
     /**
      * @covers ParagonIE_Sodium_Core_Poly1305::onetimeauth()
      * @ref https://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04#page-12

--- a/tests/unit/Salsa20Test.php
+++ b/tests/unit/Salsa20Test.php
@@ -2,6 +2,11 @@
 
 class Salsa20Test extends PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        ParagonIE_Sodium_Compat::$disableFallbackForUnitTests = true;
+    }
+
     /**
      * @covers ParagonIE_Sodium_Core_Salsa20::rotate()
      */

--- a/tests/unit/SipHashTest.php
+++ b/tests/unit/SipHashTest.php
@@ -1,0 +1,67 @@
+<?php
+
+class SipHashTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        ParagonIE_Sodium_Compat::$disableFallbackForUnitTests = true;
+    }
+
+    public function testRotl64()
+    {
+        $this->assertSame(
+            array(0x00010000, 0x00000000),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 16),
+            'rotl_64 by 16'
+        );
+        $this->assertSame(
+            array(0x80000000, 0x00000000),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 31),
+            'rotl_64 by 31'
+        );
+        $this->assertSame(
+            array(0x80000000, 0x00000000),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 95),
+            'rotl_64 by 95'
+        );
+        $this->assertSame(
+            array(0x00000000, 0x00000001),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 32),
+            'rotl_64 by 32'
+        );
+        $this->assertSame(
+            array(0x00000000, 0x00000008),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 35),
+            'rotl_64 by 35'
+        );
+        $this->assertSame(
+            array(0x00000000, 0x80000000),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 63),
+            'rotl_64 by 63'
+        );
+        $this->assertSame(
+            array(0x00000001, 0x00000000),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 64),
+            'rotl_64 by 64'
+        );
+        $this->assertSame(
+            array(0x7DDF575A, 0x3BD5BD5B),
+            ParagonIE_Sodium_Core_SipHash::rotl_64(0xDEADBEEF, 0xABAD1DEA, 17),
+            'rotl_64 by 64'
+        );
+    }
+
+    /**
+     *
+     */
+    public function testCryptoShorthash()
+    {
+        $message = 'this is just a test message';
+        $key = str_repeat("\x80", 16);
+
+        $this->assertSame(
+            '3f188259b01151a7',
+            bin2hex(ParagonIE_Sodium_Compat::crypto_shorthash($message, $key))
+        );
+    }
+}

--- a/tests/unit/SipHashTest.php
+++ b/tests/unit/SipHashTest.php
@@ -7,6 +7,64 @@ class SipHashTest extends PHPUnit_Framework_TestCase
         ParagonIE_Sodium_Compat::$disableFallbackForUnitTests = true;
     }
 
+    /**
+     * @covers ParagonIE_Sodium_Core_SipHash::add()
+     */
+    public function testAdd()
+    {
+        if (PHP_INT_SIZE === 4) {
+            $this->markTestSkipped('Test should be performed on a 64-bit OS');
+            return;
+        }
+
+        $vectors = array(
+            array(
+                0x0123456789abcdef,
+                0x456789abcdef0123,
+                0x468acf13579acf12
+            ),
+            array(
+                0x0000000100000000,
+                0x0000000000000100,
+                0x0000000100000100
+            ),
+            array(
+                0x0000000100000000,
+                0x0000000000000100,
+                0x0000000100000100
+            ),
+            array(
+                0x0fffffffffffffff,
+                0x0000000000000001,
+                0x1000000000000000
+            )
+        );
+        foreach ($vectors as $v) {
+            list($a, $b, $c) = $v;
+            # $this->assertSame($c, PHP_INT_MAX & ($a + $b));
+
+            $sA = array(
+                $a >> 32,
+                $a & 0xffffffff
+            );
+            $sB = array(
+                $b >> 32,
+                $b & 0xffffffff
+            );
+            $sC = array(
+                ($c >> 32) & 0xffffffff,
+                $c & 0xffffffff
+            );
+            $this->assertSame(
+                $sC,
+                ParagonIE_Sodium_Core_SipHash::add($sA, $sB)
+            );
+        }
+    }
+
+    /**
+     * @covers ParagonIE_Sodium_Core_SipHash::rotl_64()
+     */
     public function testRotl64()
     {
         $this->assertSame(

--- a/tests/unit/SipHashTest.php
+++ b/tests/unit/SipHashTest.php
@@ -80,7 +80,7 @@ class SipHashTest extends PHPUnit_Framework_TestCase
         $this->assertSame(
             array(0x80000000, 0x00000000),
             ParagonIE_Sodium_Core_SipHash::rotl_64(0x00000001, 0x00000000, 95),
-            'rotl_64 by 95'
+            'rotl_64 by 95 (reduce to 31)'
         );
         $this->assertSame(
             array(0x00000000, 0x00000001),


### PR DESCRIPTION
Closes #6 

Note that this was slightly more challenging than a direct port because I chose to make it only use 32-bit integers and SipHash was designed with 64-bit integers in mind.

The reason for choosing to use 32-bit integers is that many PHP 5 users do not have access to 64-bit integers, and if we want maximum compatibility (see #1), we have to make sure it will work on these platforms.