### PR TITLE
Typo in exceptions messages

### DIFF
--- a/src/Core/Ed25519.php
+++ b/src/Core/Ed25519.php
@@ -55,7 +55,7 @@ abstract class ParagonIE_Sodium_Core_Ed25519 extends ParagonIE_Sodium_Core_Curve
     public static function secretkey($keypair)
     {
         if (self::strlen($keypair) !== self::KEYPAIR_BYTES) {
-            throw new RangeException('crypto_sign keypair seed must be 32 bytes long');
+            throw new RangeException('crypto_sign keypair must be 96 bytes long');
         }
         return self::substr($keypair, 0, 64);
     }
@@ -69,7 +69,7 @@ abstract class ParagonIE_Sodium_Core_Ed25519 extends ParagonIE_Sodium_Core_Curve
     public static function publickey($keypair)
     {
         if (self::strlen($keypair) !== self::KEYPAIR_BYTES) {
-            throw new RangeException('crypto_sign keypair seed must be 32 bytes long');
+            throw new RangeException('crypto_sign keypair must be 96 bytes long');
         }
         return self::substr($keypair, 64, 32);
     }


### PR DESCRIPTION
The same message was copied into 3 places, while second and third are keypairs rather than seed.