### PR TITLE
Fix HHVM, prepare PHP 5.3 test for travis switch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 sudo: false
+dist: trusty
 
 matrix:
   fast_finish: true
   include:
     - php: "5.3"
       env: USE_PSALM=0
+      dist: precise
     - php: "5.4"
       env: USE_PSALM=0
     - php: "5.5"


### PR DESCRIPTION
Opt in to trusty early to fix hhvm, hold php5.3 on precise. Should open a bug to remove `dist: trusty` when travis makes the switch. 5.3 needs to be locked on precise though.