### PR TITLE
Use specific versions of Psalm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
 
 install:
     - composer self-update
-    - if [[ $USE_PSALM -eq 1 ]]; then composer require --dev "vimeo/psalm:^1|^2"; fi
+    - if [[ $USE_PSALM -eq 1 ]]; then composer require --dev "vimeo/psalm:1.1.4|2.0.5"; fi
     - composer update
 
 script:


### PR DESCRIPTION
The newest version of Psalm introduced a bug with polyfilled classes. While I work on fixing that bug, this PR reverts to the newest-but-one version of Psalm. Apologies!