### PR TITLE
Ensure sodium_memzero() wipe the string when libsodium-php 1.x is used

### DIFF
--- a/src/Compat.php
+++ b/src/Compat.php
@@ -2592,8 +2592,11 @@ class ParagonIE_Sodium_Compat
             return;
         }
         if (self::use_fallback('memzero')) {
-            @call_user_func('\\Sodium\\memzero', $var);
-            return;
+            $func = '\\Sodium\\memzero';
+            $func($var);
+            if ($var === null) {
+                return;
+            }
         }
         // This is the best we can do.
         throw new SodiumException(


### PR DESCRIPTION
Pass the value by reference to \Sodium\memzero() and ensure the value seems to have been wiped to not silent an issue.

This is related to #73.

Using the same strategy with `\Sodium\increment()` or variants of it with `call_user_func_array()` or `ReflectionFunction::invokeArgs()` does not seem to work. I'm not quite sure why at the moment.