### PR TITLE
Big typo

### DIFF
--- a/namespaced/Core/Salsa20.php
+++ b/namespaced/Core/Salsa20.php
@@ -1,7 +1,7 @@
 <?php
 namespace ParagonIE\Sodium\Core;
 
-class SipHash extends \ParagonIE_Sodium_Core_Salsa20
+class Salsa20 extends \ParagonIE_Sodium_Core_Salsa20
 {
 
 }


### PR DESCRIPTION
@paragonie-security maybe no one noticed

I've found it in WordPress 5.2