### PR TITLE
Fix for BLAKE2b on 32-bit platforms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
 /*
  * ISC License
  *
- * Copyright (c) 2016-2018
+ * Copyright (c) 2016-2019
  * Paragon Initiative Enterprises <security at paragonie dot com>
  *
- * Copyright (c) 2013-2018
+ * Copyright (c) 2013-2019
  * Frank Denis <j at pureftpd dot org>
  *
  * Permission to use, copy, modify, and/or distribute this software for any

--- a/autoload-phpunit.php
+++ b/autoload-phpunit.php
@@ -2,6 +2,6 @@
 
 require_once (dirname(__FILE__) . '/vendor/autoload.php');
 
-if (PHP_VERSION_ID >= 70000) {
+if (PHP_VERSION_ID >= 50300) {
     require_once (dirname(__FILE__) . '/tests/phpunit-shim.php');
 }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     "paragonie/random_compat": ">=1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^3|^4|^5"
+    "phpunit/phpunit": "^3|^4|^5|^6|^7"
   },
   "suggest": {
     "ext-libsodium": "PHP < 7.0: Better performance, password hashing (Argon2i), secure memory management (memzero), and better security.",

--- a/src/Core/BLAKE2b.php
+++ b/src/Core/BLAKE2b.php
@@ -777,7 +777,6 @@ abstract class ParagonIE_Sodium_Core_BLAKE2b extends ParagonIE_Sodium_Core_Util
         # uint8_t buf[2 * 128];
         $ctx[3] = self::stringToSplFixedArray(self::substr($string, 96, 256));
 
-
         # uint8_t buf[2 * 128];
         $int = 0;
         for ($i = 0; $i < 8; ++$i) {

--- a/src/Core32/BLAKE2b.php
+++ b/src/Core32/BLAKE2b.php
@@ -543,7 +543,8 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
         $ctx[0][0] = self::xor64(
             $ctx[0][0],
             self::load64($p, 0)
-        );;
+        );
+
         if ($salt instanceof SplFixedArray || $personal instanceof SplFixedArray) {
             // We need to do what blake2b_init_param() does:
             for ($i = 1; $i < 8; ++$i) {
@@ -563,9 +564,6 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
                 $block[$i] = $key[$i];
             }
             self::update($ctx, $block, 128);
-            for ($i = $klen; $i--;) {
-                $ctx[3][$i] = 0;
-            }
             $ctx[4] = 128;
         }
 
@@ -629,7 +627,7 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
             }
             /** @var ParagonIE_Sodium_Core32_Int64 $ctxAi */
             $ctxAi = $ctxA[$i];
-            $str .= $ctxAi->toString();
+            $str .= $ctxAi->toReverseString();
         }
 
         # uint64_t t[2];
@@ -642,8 +640,8 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
             /** @var ParagonIE_Sodium_Core32_Int64 $ctxA2 */
             $ctxA2 = $ctxA[1];
 
-            $str .= $ctxA1->toString();
-            $str .= $ctxA2->toString();
+            $str .= $ctxA1->toReverseString();
+            $str .= $ctxA2->toReverseString();
         }
 
         # uint8_t buf[2 * 128];
@@ -658,10 +656,13 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
             self::intToChr(($ctx4 >> 8) & 0xff),
             self::intToChr(($ctx4 >> 16) & 0xff),
             self::intToChr(($ctx4 >> 24) & 0xff),
+            "\x00\x00\x00\x00"
+            /*
             self::intToChr(($ctx4 >> 32) & 0xff),
             self::intToChr(($ctx4 >> 40) & 0xff),
             self::intToChr(($ctx4 >> 48) & 0xff),
             self::intToChr(($ctx4 >> 56) & 0xff)
+            */
         ));
         # uint8_t last_node;
         return $str . self::intToChr($ctx[5]) . str_repeat("\x00", 23);
@@ -686,7 +687,7 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
 
         # uint64_t h[8];
         for ($i = 0; $i < 8; ++$i) {
-            $ctx[0][$i] = ParagonIE_Sodium_Core32_Int64::fromString(
+            $ctx[0][$i] = ParagonIE_Sodium_Core32_Int64::fromReverseString(
                 self::substr($string, (($i << 3) + 0), 8)
             );
         }
@@ -694,17 +695,16 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
         # uint64_t t[2];
         # uint64_t f[2];
         for ($i = 1; $i < 3; ++$i) {
-            $ctx[$i][1] = ParagonIE_Sodium_Core32_Int64::fromString(
+            $ctx[$i][1] = ParagonIE_Sodium_Core32_Int64::fromReverseString(
                 self::substr($string, 72 + (($i - 1) << 4), 8)
             );
-            $ctx[$i][0] = ParagonIE_Sodium_Core32_Int64::fromString(
+            $ctx[$i][0] = ParagonIE_Sodium_Core32_Int64::fromReverseString(
                 self::substr($string, 64 + (($i - 1) << 4), 8)
             );
         }
 
         # uint8_t buf[2 * 128];
         $ctx[3] = self::stringToSplFixedArray(self::substr($string, 96, 256));
-
 
         # uint8_t buf[2 * 128];
         $int = 0;

--- a/tests/Windows32Test.php
+++ b/tests/Windows32Test.php
@@ -12,6 +12,69 @@ class Windows32Test extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @throws SodiumException
+     */
+    public function testBlake2bPersonalizedState()
+    {
+        $exp = ParagonIE_Sodium_Core32_Util::hex2bin(
+            '48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5e4e0d0cf4b636b35260e0d1fbf0e60ab' .
+            '5e8c73cdcdbbb17e4a164a2329a9d23a0000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        $k = '';
+        $salt = '5b6b41ed9b343fe0';
+        $personal = '5126fb2a37400d2a';
+
+        for ($h = 0; $h < 64; ++$h) {
+            $k[$h] = ParagonIE_Sodium_Core32_Util::intToChr($h);
+        }
+
+        $state = ParagonIE_Sodium_Compat::crypto_generichash_init_salt_personal('', 64, $salt, $personal);
+
+        // Chop off last 17 bytes if present because they'll throw off tests:
+        $a = ParagonIE_Sodium_Core32_Util::substr($state, 0, 361);
+        $b = ParagonIE_Sodium_Core32_Util::substr($exp, 0, 361);
+        $this->assertEquals(
+            ParagonIE_Sodium_Core32_Util::bin2hex($b),
+            ParagonIE_Sodium_Core32_Util::bin2hex($a),
+            'Initialized value is incorrect'
+        );
+
+        $in = '';
+
+        for ($i = 0; $i < 64; ++$i) {
+            $in .= ParagonIE_Sodium_Core32_Util::intToChr($i);
+        }
+        ParagonIE_Sodium_Compat::crypto_generichash_update($state, $in);
+
+        $exp2 = ParagonIE_Sodium_Core_Util::hex2bin(
+            '48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5e4e0d0cf4b636b35260e0d1fbf0e60ab' .
+            '5e8c73cdcdbbb17e4a164a2329a9d23a0000000000000000000000000000000000000000000000000000000000000000' .
+            '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f' .
+            '303132333435363738393a3b3c3d3e3f0000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' .
+            '000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000'
+        );
+
+        // Chop off last 17 bytes if present because they'll throw off tests:
+        $a = ParagonIE_Sodium_Core32_Util::substr($state, 0, 361);
+        $b = ParagonIE_Sodium_Core32_Util::substr($exp2, 0, 361);
+        $this->assertEquals(
+            ParagonIE_Sodium_Core32_Util::bin2hex($b),
+            ParagonIE_Sodium_Core32_Util::bin2hex($a),
+            'Updated value is incorrect'
+        );
+    }
+
+    /**
      * @covers ParagonIE_Sodium_Compat::crypto_auth()
      * @covers ParagonIE_Sodium_Compat::crypto_auth_verify()
      * @throws SodiumException


### PR DESCRIPTION
Internal state was being constructed with the incorrect byte order.

This PR also attempts to support PHPUnit 6 and 7 in all versions of PHP (if applicable).