### PR TITLE
Bugfix: mbstring function overloading has been removed in php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,17 +47,11 @@ matrix:
       dist: bionic
       env: USE_PSALM=0
            CHECK_MBSTRING=0
-    - php: "master"
-      dist: bionic
-      env: USE_PSALM=0
-           CHECK_MBSTRING=0
     - php: "hhvm-3.24"
       dist: trusty
       env: USE_PSALM=0
            CHECK_MBSTRING=1
   allow_failures:
-    - php: "nightly"
-    - php: "master"
     - php: "hhvm-3.24"
 
 install:
@@ -68,6 +62,7 @@ install:
     - if [[ ${TRAVIS_PHP_VERSION:0:3} != "7.4" ]] && [[ $USE_PSALM -eq 1 ]]; then composer require --dev "vimeo/psalm:^1|^2"; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then `cp psalm-above-3.xml psalm.xml`; else `cp psalm-below-3.xml psalm.xml`; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]]; then chmod +x tests/fix-php52.sh; fi
+    - if [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then composer config platform.php 7.4.99; fi
     - gitcommit=$(git rev-parse HEAD) && composer config autoloader-suffix "$gitcommit"
     - composer update
     - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.2" ]]; then tests/fix-php52.sh; fi

--- a/src/Core/Util.php
+++ b/src/Core/Util.php
@@ -911,6 +911,7 @@ abstract class ParagonIE_Sodium_Core_Util
 
         if ($mbstring === null) {
             $mbstring = extension_loaded('mbstring')
+                && defined('MB_OVERLOAD_STRING')
                 &&
             ((int) (ini_get('mbstring.func_overload')) & MB_OVERLOAD_STRING);
         }


### PR DESCRIPTION
On php 8, the `MB_OVERLOAD_STRING` constant has been removed together with the mbstring function overload feature. In order to avoid an error when accessing the constant, I've saveguarded the access with a `defined()` call.