### PR TITLE
Remove the term "blacklist"

### DIFF
--- a/src/Core/Ed25519.php
+++ b/src/Core/Ed25519.php
@@ -376,8 +376,8 @@ abstract class ParagonIE_Sodium_Core_Ed25519 extends ParagonIE_Sodium_Core_Curve
      */
     public static function small_order($R)
     {
-        /** @var array<int, array<int, int>> $blacklist */
-        $blacklist = array(
+        /** @var array<int, array<int, int>> $blocklist */
+        $blocklist = array(
             /* 0 (order 4) */
             array(
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -463,13 +463,13 @@ abstract class ParagonIE_Sodium_Core_Ed25519 extends ParagonIE_Sodium_Core_Curve
                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
             )
         );
-        /** @var int $countBlacklist */
-        $countBlacklist = count($blacklist);
+        /** @var int $countBlocklist */
+        $countBlocklist = count($blocklist);
 
-        for ($i = 0; $i < $countBlacklist; ++$i) {
+        for ($i = 0; $i < $countBlocklist; ++$i) {
             $c = 0;
             for ($j = 0; $j < 32; ++$j) {
-                $c |= self::chrToInt($R[$j]) ^ (int) $blacklist[$i][$j];
+                $c |= self::chrToInt($R[$j]) ^ (int) $blocklist[$i][$j];
             }
             if ($c === 0) {
                 return true;

--- a/src/Core32/Ed25519.php
+++ b/src/Core32/Ed25519.php
@@ -378,7 +378,7 @@ abstract class ParagonIE_Sodium_Core32_Ed25519 extends ParagonIE_Sodium_Core32_C
      */
     public static function small_order($R)
     {
-        static $blacklist = array(
+        static $blocklist = array(
             /* 0 (order 4) */
             array(
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -464,13 +464,13 @@ abstract class ParagonIE_Sodium_Core32_Ed25519 extends ParagonIE_Sodium_Core32_C
                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
             )
         );
-        /** @var array<int, array<int, int>> $blacklist */
-        $countBlacklist = count($blacklist);
+        /** @var array<int, array<int, int>> $blocklist */
+        $countBlocklist = count($blocklist);
 
-        for ($i = 0; $i < $countBlacklist; ++$i) {
+        for ($i = 0; $i < $countBlocklist; ++$i) {
             $c = 0;
             for ($j = 0; $j < 32; ++$j) {
-                $c |= self::chrToInt($R[$j]) ^ $blacklist[$i][$j];
+                $c |= self::chrToInt($R[$j]) ^ $blocklist[$i][$j];
             }
             if ($c === 0) {
                 return true;


### PR DESCRIPTION
There are more inclusive terms that can be used instead. This PR changes all occurrences of "blacklist" to "blocklist".

Part of the efforts in https://core.trac.wordpress.org/ticket/50413.