### PR TITLE
Coerce the autoloading of the primary class

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -41,6 +41,9 @@ if (PHP_VERSION_ID < 70000) {
     require_once dirname(__FILE__) . '/autoload-php7.php';
 }
 
+/* Explicitly, always load the Compat class: */
+require_once dirname(__FILE__) . '/src/Compat.php';
+
 if (!class_exists('SodiumException', false)) {
     require_once dirname(__FILE__) . '/src/SodiumException.php';
 }

--- a/src/Core/BLAKE2b.php
+++ b/src/Core/BLAKE2b.php
@@ -644,6 +644,7 @@ abstract class ParagonIE_Sodium_Core_BLAKE2b extends ParagonIE_Sodium_Core_Util
      *
      * @param string $str
      * @return SplFixedArray
+     * @psalm-suppress MixedArgumentTypeCoercion
      */
     public static function stringToSplFixedArray($str = '')
     {

--- a/src/Core32/BLAKE2b.php
+++ b/src/Core32/BLAKE2b.php
@@ -577,6 +577,7 @@ abstract class ParagonIE_Sodium_Core32_BLAKE2b extends ParagonIE_Sodium_Core_Uti
      *
      * @param string $str
      * @return SplFixedArray
+     * @psalm-suppress MixedArgumentTypeCoercion
      */
     public static function stringToSplFixedArray($str = '')
     {


### PR DESCRIPTION
Possible fix for #122 by coercing the autoloader to always load the `ParagonIE_Sodium_Compat` class before the remaining polyfills (constants, etc.).