### PR TITLE
PHP 8.1: fix deprecation warnings

### DIFF
--- a/src/Core/ChaCha20/Ctx.php
+++ b/src/Core/ChaCha20/Ctx.php
@@ -69,6 +69,7 @@ class ParagonIE_Sodium_Core_ChaCha20_Ctx extends ParagonIE_Sodium_Core_Util impl
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!is_int($offset)) {
@@ -86,6 +87,7 @@ class ParagonIE_Sodium_Core_ChaCha20_Ctx extends ParagonIE_Sodium_Core_Util impl
      * @param int $offset
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -98,6 +100,7 @@ class ParagonIE_Sodium_Core_ChaCha20_Ctx extends ParagonIE_Sodium_Core_Util impl
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -110,6 +113,7 @@ class ParagonIE_Sodium_Core_ChaCha20_Ctx extends ParagonIE_Sodium_Core_Util impl
      * @return mixed|null
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset])

--- a/src/Core/Curve25519/Fe.php
+++ b/src/Core/Curve25519/Fe.php
@@ -60,6 +60,7 @@ class ParagonIE_Sodium_Core_Curve25519_Fe implements ArrayAccess
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!is_int($value)) {
@@ -79,6 +80,7 @@ class ParagonIE_Sodium_Core_Curve25519_Fe implements ArrayAccess
      * @return bool
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -91,6 +93,7 @@ class ParagonIE_Sodium_Core_Curve25519_Fe implements ArrayAccess
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -103,6 +106,7 @@ class ParagonIE_Sodium_Core_Curve25519_Fe implements ArrayAccess
      * @return int
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!isset($this->container[$offset])) {

--- a/src/Core32/ChaCha20/Ctx.php
+++ b/src/Core32/ChaCha20/Ctx.php
@@ -70,6 +70,7 @@ class ParagonIE_Sodium_Core32_ChaCha20_Ctx extends ParagonIE_Sodium_Core32_Util 
      * @param int|ParagonIE_Sodium_Core32_Int32 $value
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!is_int($offset)) {
@@ -93,6 +94,7 @@ class ParagonIE_Sodium_Core32_ChaCha20_Ctx extends ParagonIE_Sodium_Core32_Util 
      * @return bool
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -105,6 +107,7 @@ class ParagonIE_Sodium_Core32_ChaCha20_Ctx extends ParagonIE_Sodium_Core32_Util 
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -117,6 +120,7 @@ class ParagonIE_Sodium_Core32_ChaCha20_Ctx extends ParagonIE_Sodium_Core32_Util 
      * @return mixed|null
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->container[$offset])

--- a/src/Core32/Curve25519/Fe.php
+++ b/src/Core32/Curve25519/Fe.php
@@ -104,6 +104,7 @@ class ParagonIE_Sodium_Core32_Curve25519_Fe implements ArrayAccess
      * @throws SodiumException
      * @throws TypeError
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!($value instanceof ParagonIE_Sodium_Core32_Int32)) {
@@ -124,6 +125,7 @@ class ParagonIE_Sodium_Core32_Curve25519_Fe implements ArrayAccess
      * @return bool
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -136,6 +138,7 @@ class ParagonIE_Sodium_Core32_Curve25519_Fe implements ArrayAccess
      * @return void
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -148,6 +151,7 @@ class ParagonIE_Sodium_Core32_Curve25519_Fe implements ArrayAccess
      * @return ParagonIE_Sodium_Core32_Int32
      * @psalm-suppress MixedArrayOffset
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!isset($this->container[$offset])) {


### PR DESCRIPTION
As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this package has a minimum PHP requirement of PHP 5.2 based on the `composer.json` file, the return type (PHP 7.0 feature) can not be added, so I've added the attribute instead.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.

Note: I've not applied this patch to the `src/PHP52/SplFixedArray.php` file as that file is only loaded on PHP 5.2, so would not run into this issue.