### PR TITLE
GH Actions: fix the workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ['ubuntu-16.04']
+        operating-system: ['ubuntu-18.04']
         php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0']
         phpunit-versions: ['7.5.20']
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl
           ini-values: post_max_size=256M, max_execution_time=180
-          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          tools: phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
       - name: Use Composer 1.x
@@ -53,7 +53,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, sodium
           ini-values: post_max_size=256M, max_execution_time=180
-          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          tools: phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
       - name: Install Composer dependencies
@@ -83,7 +83,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, sodium
           ini-values: post_max_size=256M, max_execution_time=180
-          tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          tools: phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
       - name: Install Composer dependencies
@@ -94,9 +94,3 @@ jobs:
         timeout-minutes: 30
         with:
           memory_limit: 256M
-
-      - name: Install Psalm
-        run: composer require --dev vimeo/psalm:^4; cp psalm-above-3.xml psalm.xml
-
-      - name: Static Analysis
-        run: vendor/bin/psalm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: ['ubuntu-18.04']
         php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
-      - name: Install dependencies
-        run: composer self-update --1; composer install
+      - name: Use Composer 1.x
+        run: composer self-update --1
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
         uses: php-actions/phpunit@v2
@@ -53,8 +56,8 @@ jobs:
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
-      - name: Install dependencies
-        run: composer install
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
         uses: php-actions/phpunit@v2
@@ -83,8 +86,8 @@ jobs:
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
-      - name: Install dependencies
-        run: composer install
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
         uses: php-actions/phpunit@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl
-          ini-values: max_execution_time=600, memory_limit=256M
+          ini-values: max_execution_time=600, memory_limit=256M, error_reporting=-1, display_errors=On
           coverage: none
 
       - name: Use Composer 1.x
@@ -47,6 +47,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, sodium
+          ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
       - name: Install Composer dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+
+    continue-on-error: ${{ matrix.php-versions == '8.1' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -50,8 +53,15 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
-      - name: Install Composer dependencies
+      - name: Install Composer dependencies (PHP < 8.1)
+        if: ${{ matrix.php-versions != '8.1' }}
         uses: "ramsey/composer-install@v1"
+
+      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.1)
+        if: ${{ matrix.php-versions == '8.1' }}
+        uses: "ramsey/composer-install@v1"
+        with:
+          composer-options: --ignore-platform-reqs
 
       - name: PHPUnit tests
         run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           extensions: mbstring, intl
           ini-values: post_max_size=256M, max_execution_time=180
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          coverage: none
 
       - name: Install dependencies
         run: composer self-update --1; composer install
@@ -50,6 +51,7 @@ jobs:
           extensions: mbstring, intl, sodium
           ini-values: post_max_size=256M, max_execution_time=180
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          coverage: none
 
       - name: Install dependencies
         run: composer install
@@ -79,6 +81,7 @@ jobs:
           extensions: mbstring, intl, sodium
           ini-values: post_max_size=256M, max_execution_time=180
           tools: psalm, phpunit:${{ matrix.phpunit-versions }}
+          coverage: none
 
       - name: Install dependencies
         run: composer install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         operating-system: ['ubuntu-18.04']
         php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0']
-        phpunit-versions: ['7.5.20']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,8 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl
-          ini-values: post_max_size=256M, max_execution_time=180
-          tools: phpunit:${{ matrix.phpunit-versions }}
+          ini-values: max_execution_time=600, memory_limit=256M
           coverage: none
 
       - name: Use Composer 1.x
@@ -31,9 +29,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
-        uses: php-actions/phpunit@v2
-        with:
-          memory_limit: 256M
+        run: vendor/bin/phpunit
 
   moderate:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
@@ -42,7 +38,6 @@ jobs:
       matrix:
         operating-system: ['ubuntu-latest']
         php-versions: ['7.1', '7.2', '7.3']
-        phpunit-versions: ['latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,18 +47,13 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, sodium
-          ini-values: post_max_size=256M, max_execution_time=180
-          tools: phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
-        uses: php-actions/phpunit@v2
-        timeout-minutes: 30
-        with:
-          memory_limit: 256M
+        run: vendor/bin/phpunit
 
   modern:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
@@ -72,7 +62,6 @@ jobs:
       matrix:
         operating-system: ['ubuntu-latest']
         php-versions: ['7.4', '8.0']
-        phpunit-versions: ['latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -82,15 +71,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, sodium
-          ini-values: post_max_size=256M, max_execution_time=180
-          tools: phpunit:${{ matrix.phpunit-versions }}
           coverage: none
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v1"
 
       - name: PHPUnit tests
-        uses: php-actions/phpunit@v2
-        timeout-minutes: 30
-        with:
-          memory_limit: 256M
+        run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,37 +31,13 @@ jobs:
       - name: PHPUnit tests
         run: vendor/bin/phpunit
 
-  moderate:
+  moderate-modern:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.1', '7.2', '7.3']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, sodium
-          coverage: none
-
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
-
-      - name: PHPUnit tests
-        run: vendor/bin/phpunit
-
-  modern:
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,33 @@
+name: Psalm
+
+on: [push]
+
+jobs:
+  psalm:
+    name: Psalm on PHP ${{ matrix.php-versions }}
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: psalm:4
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+        with:
+          composer-options: --no-dev
+
+      - name: Put Psalm config in place
+        run: cp psalm-above-3.xml psalm.xml
+
+      - name: Static Analysis
+        run: psalm


### PR DESCRIPTION
I came to send in PR #134 and to turn on testing against PHP 8.1, I stayed to make a lot more fixes to the CI workflows... 😂 

TL;DR: The tests on PHP 5.3-5.6 were not running at all, which meant that it was missed that the changes in commit 8e0e0210fe6e0d816de4effd62e9bcbc20fe9889 are not compatible with PHP < 7.0.
Turning the tests on, now exposes this.

Please check out the various commit messages and the action run results to get the full picture.


## Commit details

### GH Actions: ubuntu-16.04 is no longer supported

... use `ubuntu-18.04` or `ubuntu-latest` for `20.04` instead.

Also see:
* https://ubuntu.com/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm
* shivammathur/setup-php#452

### GH Actions: explicitly set code coverage to none

As no code coverage is being recorded for these builds, it is good practice to explicitly set `coverage: none` in `setup-php`.
This fixes a warning during the Composer run on PHP 5.3 stating that Xdebug is on.

### GH Actions: enable Composer caching

... by using the `ramsey/composer-install` action.

This means that the Composer downloads directory for dependencies will be cached and restored on each build. This conserves resources and should also make builds faster.

Ref: https://github.com/marketplace/actions/install-composer-dependencies

### GH Actions: split off Psalm to separate workflow

Psalm does not need to be run against multiple PHP versions. Running it once should be enough.

With that in mind, this commit:
* Introduces a separate, dedicated workflow which only installs and runs Psalm.
* Removes the Psalm related steps from the `CI` workflow.
* Removes Psalm from the `tools` setting for `setup-php`.

Note: if so desired I could add Psalm as a separate job to the main workflow instead. Having it as a separate workflow makes sense to my brain ;-)

### GH Actions: fix running of the tests

While the builds currently all show "green", if you actually fold out the "PHPUnit Tests" step for the builds in the last CI run against `master`, you can see that the tests haven't been running on PHP 5.3, 5.4, 5.5, 5.6.

As of PHP 7.0, they _have_ been running, but running against a mismatched PHPUnit version as all test runs are run against PHPUnit 9.5.x, while PHPUnit 9.5 is officially only supported on PHP 7.3 and higher.

Additionally, PHPUnit was being installed 3 (!) times, once via the `setup-php` action, once via the `composer install` and once via the `php-actions/phpunit` action.

To ensure that the tests are always run against the most appropriate PHPUnit version for the PHP version against which the tests are being run, I propose to:
* Remove the installing of PHPUnit via `setup-php`.
* Remove the use of the `php-actions/phpunit` action.
* Defer to the Composer installed PHPUnit version in all cases.

I'm also removing the explicit ini settings for the "moderate" and "modern" jobs.
These look like they were copied over from example code, but these values don't have any effect on the test runs in these workflows, so may as well be removed.

For the "low" job, however, having some ini values set prevents the tests erroring out too quickly.

### GH Actions: merge "moderate" and "modern" jobs

As there is now effectively no difference anymore between the `moderate` and `modern` jobs, these jobs can now be merged into one.

### GH Actions: set error reporting to -1

The default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `-1` and `display_errors=On` to ensure **all** PHP notices are shown.

Ref: shivammathur/setup-php#469

### GH Actions: enable testing against PHP 8.1

For now, this build is still allowed to fail.

### GH Actions: don't fail fast on "low" PHP versions

I'd like to suggest adding this as a temporary measure until the failing code has been fixed.

The `fail-fast` setting defaults to `true` and has the effect of cancelling any and all running/waiting builds within the same workflow as soon as one build has failed.

By setting this to `false`, all builds will be always be run, allowing for easier debugging of the current test failures.

