### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases