### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.gitattributes export-ignore
+/.gitignore export-ignore
 /.github export-ignore
 /phpunit.xml.dist export-ignore
 /phpstan.neon.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,14 @@
 /.gitattributes export-ignore
-/.travis.yml export-ignore
-/phpunit.xml export-ignore
+/.github export-ignore
+/phpunit.xml.dist export-ignore
 /phpstan.neon.dist export-ignore
-/psalm.xml export-ignore
+/psalm-above-3.xml export-ignore
+/psalm-below-3.xml export-ignore
 /tests export-ignore
+/build-phar.sh export-ignore
+/appveyor.yml export-ignore
+/dist export-ignore
+/autoload-phpunit.php export-ignore
+/autoload-pedantic.php export-ignore
+/autoload-fast.php export-ignore
+


### PR DESCRIPTION
There is a lot of unnecessary files for people installing this project with composer on their server

Found at phpMyAdmin by my script:
```
Searching for files
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/.github/
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/.github/workflows/
Found unexpected file: vendor/paragonie/sodium_compat/.github/workflows/ci.yml with extension yml
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/.github/workflows/ci.yml
Found unexpected file: vendor/paragonie/sodium_compat/.github/workflows/psalm.yml with extension yml
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/.github/workflows/psalm.yml
Found unexpected file: vendor/paragonie/sodium_compat/appveyor.yml with extension yml
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/appveyor.yml
Found unexpected file: vendor/paragonie/sodium_compat/build-phar.sh with extension sh
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/build-phar.sh
Found unexpected file: vendor/paragonie/sodium_compat/composer-php52.json with extension json
Found unexpected file: vendor/paragonie/sodium_compat/dist/Makefile with extension Makefile
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/dist/Makefile
Found unexpected file: vendor/paragonie/sodium_compat/dist/box.json with extension json
Found unexpected file: vendor/paragonie/sodium_compat/phpunit.xml.dist with extension dist
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/phpunit.xml.dist
Found unexpected file: vendor/paragonie/sodium_compat/psalm-above-3.xml with extension xml
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/psalm-above-3.xml
Found unexpected file: vendor/paragonie/sodium_compat/psalm-below-3.xml with extension xml
Found: phpMyAdmin-5.2.1-dev-all-languages/vendor/paragonie/sodium_compat/psalm-below-3.xml
```