### PR TITLE
Less reliance on include guards that return early

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -42,7 +42,9 @@ if (PHP_VERSION_ID < 70000) {
 }
 
 /* Explicitly, always load the Compat class: */
-require_once dirname(__FILE__) . '/src/Compat.php';
+if (!class_exists('ParagonIE_Sodium_Compat')) {
+    require_once dirname(__FILE__) . '/src/Compat.php';
+}
 
 if (!class_exists('SodiumException', false)) {
     require_once dirname(__FILE__) . '/src/SodiumException.php';


### PR DESCRIPTION
This may help with errors induced by opcache preloading.

#148 