### PR TITLE
Adds directory to require_once calls.

### DIFF
--- a/autoload-fast.php
+++ b/autoload-fast.php
@@ -1,4 +1,4 @@
 <?php
 
-require_once 'autoload.php';
+require_once DIRNAME(__FILE__) . '/autoload.php';
 ParagonIE_Sodium_Compat::$fastMult = true;

--- a/autoload-pedantic.php
+++ b/autoload-pedantic.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'autoload.php';
+require_once dirname(__FILE__) . '/autoload.php';
 define('DO_PEDANTIC_TEST', true);
 
 ParagonIE_Sodium_Compat::$fastMult = true;


### PR DESCRIPTION
Without the directory if the file autoload.php exists in a location on the load path prior it will be loaded instead causing errors.