### PR TITLE
Fix variable names to match ext/sodium

### DIFF
--- a/lib/php72compat.php
+++ b/lib/php72compat.php
@@ -110,14 +110,14 @@ foreach (array(
 if (!is_callable('sodium_add')) {
     /**
      * @see ParagonIE_Sodium_Compat::add()
-     * @param string $val
-     * @param string $addv
+     * @param string $string1
+     * @param string $string2
      * @return void
      * @throws SodiumException
      */
-    function sodium_add(&$val, $addv)
+    function sodium_add(&$string1, $string2)
     {
-        ParagonIE_Sodium_Compat::add($val, $addv);
+        ParagonIE_Sodium_Compat::add($string1, $string2);
     }
 }
 if (!is_callable('sodium_base642bin')) {
@@ -165,33 +165,41 @@ if (!is_callable('sodium_bin2hex')) {
 if (!is_callable('sodium_compare')) {
     /**
      * @see ParagonIE_Sodium_Compat::compare()
-     * @param string $a
-     * @param string $b
+     * @param string $string1
+     * @param string $string2
      * @return int
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_compare($a, $b)
+    function sodium_compare($string1, $string2)
     {
-        return ParagonIE_Sodium_Compat::compare($a, $b);
+        return ParagonIE_Sodium_Compat::compare($string1, $string2);
     }
 }
 if (!is_callable('sodium_crypto_aead_aes256gcm_decrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_decrypt()
-     * @param string $message
-     * @param string $assocData
+     * @param string $ciphertext
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_aes256gcm_decrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_aes256gcm_decrypt($ciphertext, $additional_data, $nonce, $key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_decrypt($message, $assocData, $nonce, $key);
+            return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_decrypt(
+                $ciphertext,
+                $additional_data,
+                $nonce,
+                $key
+            );
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
+            if (($ex instanceof SodiumException) && ($ex->getMessage() === 'AES-256-GCM is not available')) {
+                throw $ex;
+            }
             return false;
         }
     }
@@ -200,16 +208,16 @@ if (!is_callable('sodium_crypto_aead_aes256gcm_encrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_encrypt()
      * @param string $message
-     * @param string $assocData
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_aes256gcm_encrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_aes256gcm_encrypt($message, $additional_data, $nonce, $key)
     {
-        return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_encrypt($message, $assocData, $nonce, $key);
+        return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_encrypt($message, $additional_data, $nonce, $key);
     }
 }
 if (!is_callable('sodium_crypto_aead_aes256gcm_is_available')) {
@@ -225,16 +233,21 @@ if (!is_callable('sodium_crypto_aead_aes256gcm_is_available')) {
 if (!is_callable('sodium_crypto_aead_chacha20poly1305_decrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_decrypt()
-     * @param string $message
-     * @param string $assocData
+     * @param string $ciphertext
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_chacha20poly1305_decrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_chacha20poly1305_decrypt($ciphertext, $additional_data, $nonce, $key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_decrypt($message, $assocData, $nonce, $key);
+            return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_decrypt(
+                $ciphertext,
+                $additional_data,
+                $nonce,
+                $key
+            );
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -246,16 +259,21 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_encrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_encrypt()
      * @param string $message
-     * @param string $assocData
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_chacha20poly1305_encrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_chacha20poly1305_encrypt($message, $additional_data, $nonce, $key)
     {
-        return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_encrypt($message, $assocData, $nonce, $key);
+        return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_encrypt(
+            $message,
+            $additional_data,
+            $nonce,
+            $key
+        );
     }
 }
 if (!is_callable('sodium_crypto_aead_chacha20poly1305_keygen')) {
@@ -273,15 +291,20 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_decrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_decrypt()
      * @param string $message
-     * @param string $assocData
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_chacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_chacha20poly1305_ietf_decrypt($message, $additional_data, $nonce, $key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key);
+            return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_decrypt(
+                $message,
+                $additional_data,
+                $nonce,
+                $key
+            );
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -293,16 +316,21 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_encrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_encrypt()
      * @param string $message
-     * @param string $assocData
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_chacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_chacha20poly1305_ietf_encrypt($message, $additional_data, $nonce, $key)
     {
-        return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key);
+        return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_encrypt(
+            $message,
+            $additional_data,
+            $nonce,
+            $key
+        );
     }
 }
 if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_keygen')) {
@@ -319,16 +347,22 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_keygen')) {
 if (!is_callable('sodium_crypto_aead_xchacha20poly1305_ietf_decrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt()
-     * @param string $message
-     * @param string $assocData
+     * @param string $ciphertext
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key)
+    function sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, $additional_data, $nonce, $key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key, true);
+            return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt(
+                $ciphertext,
+                $additional_data,
+                $nonce,
+                $key,
+                true
+            );
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -340,16 +374,26 @@ if (!is_callable('sodium_crypto_aead_xchacha20poly1305_ietf_encrypt')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt()
      * @param string $message
-     * @param string $assocData
+     * @param string $additional_data
      * @param string $nonce
      * @param string $key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key)
-    {
-        return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key, true);
+    function sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+        $message,
+        $additional_data,
+        $nonce,
+        $key
+    ) {
+        return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt(
+            $message,
+            $additional_data,
+            $nonce,
+            $key,
+            true
+        );
     }
 }
 if (!is_callable('sodium_crypto_aead_xchacha20poly1305_ietf_keygen')) {
@@ -408,14 +452,14 @@ if (!is_callable('sodium_crypto_box')) {
      * @see ParagonIE_Sodium_Compat::crypto_box()
      * @param string $message
      * @param string $nonce
-     * @param string $kp
+     * @param string $key_pair
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box($message, $nonce, $kp)
+    function sodium_crypto_box($message, $nonce, $key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_box($message, $nonce, $kp);
+        return ParagonIE_Sodium_Compat::crypto_box($message, $nonce, $key_pair);
     }
 }
 if (!is_callable('sodium_crypto_box_keypair')) {
@@ -433,29 +477,29 @@ if (!is_callable('sodium_crypto_box_keypair')) {
 if (!is_callable('sodium_crypto_box_keypair_from_secretkey_and_publickey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_keypair_from_secretkey_and_publickey()
-     * @param string $sk
-     * @param string $pk
+     * @param string $secret_key
+     * @param string $public_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_keypair_from_secretkey_and_publickey($sk, $pk)
+    function sodium_crypto_box_keypair_from_secretkey_and_publickey($secret_key, $public_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_box_keypair_from_secretkey_and_publickey($sk, $pk);
+        return ParagonIE_Sodium_Compat::crypto_box_keypair_from_secretkey_and_publickey($secret_key, $public_key);
     }
 }
 if (!is_callable('sodium_crypto_box_open')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_open()
-     * @param string $message
+     * @param string $ciphertext
      * @param string $nonce
-     * @param string $kp
+     * @param string $key_pair
      * @return string|bool
      */
-    function sodium_crypto_box_open($message, $nonce, $kp)
+    function sodium_crypto_box_open($ciphertext, $nonce, $key_pair)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_box_open($message, $nonce, $kp);
+            return ParagonIE_Sodium_Compat::crypto_box_open($ciphertext, $nonce, $key_pair);
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -466,55 +510,55 @@ if (!is_callable('sodium_crypto_box_open')) {
 if (!is_callable('sodium_crypto_box_publickey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_publickey()
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_publickey($keypair)
+    function sodium_crypto_box_publickey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_box_publickey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_box_publickey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_box_publickey_from_secretkey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_publickey_from_secretkey()
-     * @param string $sk
+     * @param string $secret_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_publickey_from_secretkey($sk)
+    function sodium_crypto_box_publickey_from_secretkey($secret_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_box_publickey_from_secretkey($sk);
+        return ParagonIE_Sodium_Compat::crypto_box_publickey_from_secretkey($secret_key);
     }
 }
 if (!is_callable('sodium_crypto_box_seal')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_seal()
      * @param string $message
-     * @param string $publicKey
+     * @param string $public_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_seal($message, $publicKey)
+    function sodium_crypto_box_seal($message, $public_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_box_seal($message, $publicKey);
+        return ParagonIE_Sodium_Compat::crypto_box_seal($message, $public_key);
     }
 }
 if (!is_callable('sodium_crypto_box_seal_open')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_seal_open()
      * @param string $message
-     * @param string $kp
+     * @param string $key_pair
      * @return string|bool
      * @throws SodiumException
      */
-    function sodium_crypto_box_seal_open($message, $kp)
+    function sodium_crypto_box_seal_open($message, $key_pair)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_box_seal_open($message, $kp);
+            return ParagonIE_Sodium_Compat::crypto_box_seal_open($message, $key_pair);
         } catch (SodiumException $ex) {
             if ($ex->getMessage() === 'Argument 2 must be CRYPTO_BOX_KEYPAIRBYTES long.') {
                 throw $ex;
@@ -526,14 +570,14 @@ if (!is_callable('sodium_crypto_box_seal_open')) {
 if (!is_callable('sodium_crypto_box_secretkey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_box_secretkey()
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_secretkey($keypair)
+    function sodium_crypto_box_secretkey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_box_secretkey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_box_secretkey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_box_seed_keypair')) {
@@ -554,42 +598,42 @@ if (!is_callable('sodium_crypto_generichash')) {
      * @see ParagonIE_Sodium_Compat::crypto_generichash()
      * @param string $message
      * @param string|null $key
-     * @param int $outLen
+     * @param int $length
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash($message, $key = null, $outLen = 32)
+    function sodium_crypto_generichash($message, $key = null, $length = 32)
     {
-        return ParagonIE_Sodium_Compat::crypto_generichash($message, $key, $outLen);
+        return ParagonIE_Sodium_Compat::crypto_generichash($message, $key, $length);
     }
 }
 if (!is_callable('sodium_crypto_generichash_final')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_generichash_final()
-     * @param string|null $ctx
+     * @param string|null $state
      * @param int $outputLength
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash_final(&$ctx, $outputLength = 32)
+    function sodium_crypto_generichash_final(&$state, $outputLength = 32)
     {
-        return ParagonIE_Sodium_Compat::crypto_generichash_final($ctx, $outputLength);
+        return ParagonIE_Sodium_Compat::crypto_generichash_final($state, $outputLength);
     }
 }
 if (!is_callable('sodium_crypto_generichash_init')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_generichash_init()
      * @param string|null $key
-     * @param int $outLen
+     * @param int $length
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash_init($key = null, $outLen = 32)
+    function sodium_crypto_generichash_init($key = null, $length = 32)
     {
-        return ParagonIE_Sodium_Compat::crypto_generichash_init($key, $outLen);
+        return ParagonIE_Sodium_Compat::crypto_generichash_init($key, $length);
     }
 }
 if (!is_callable('sodium_crypto_generichash_keygen')) {
@@ -606,15 +650,15 @@ if (!is_callable('sodium_crypto_generichash_keygen')) {
 if (!is_callable('sodium_crypto_generichash_update')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_generichash_update()
-     * @param string|null $ctx
+     * @param string|null $state
      * @param string $message
      * @return void
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash_update(&$ctx, $message = '')
+    function sodium_crypto_generichash_update(&$state, $message = '')
     {
-        ParagonIE_Sodium_Compat::crypto_generichash_update($ctx, $message);
+        ParagonIE_Sodium_Compat::crypto_generichash_update($state, $message);
     }
 }
 if (!is_callable('sodium_crypto_kdf_keygen')) {
@@ -631,17 +675,17 @@ if (!is_callable('sodium_crypto_kdf_keygen')) {
 if (!is_callable('sodium_crypto_kdf_derive_from_key')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_kdf_derive_from_key()
-     * @param int $subkey_len
+     * @param int $subkey_length
      * @param int $subkey_id
      * @param string $context
      * @param string $key
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kdf_derive_from_key($subkey_len, $subkey_id, $context, $key)
+    function sodium_crypto_kdf_derive_from_key($subkey_length, $subkey_id, $context, $key)
     {
         return ParagonIE_Sodium_Compat::crypto_kdf_derive_from_key(
-            $subkey_len,
+            $subkey_length,
             $subkey_id,
             $context,
             $key
@@ -692,54 +736,54 @@ if (!is_callable('sodium_crypto_kx_keypair')) {
 }
 if (!is_callable('sodium_crypto_kx_client_session_keys')) {
     /**
-     * @param string $keypair
-     * @param string $serverPublicKey
+     * @param string $client_key_pair
+     * @param string $server_key
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    function sodium_crypto_kx_client_session_keys($keypair, $serverPublicKey)
+    function sodium_crypto_kx_client_session_keys($client_key_pair, $server_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_kx_client_session_keys($keypair, $serverPublicKey);
+        return ParagonIE_Sodium_Compat::crypto_kx_client_session_keys($client_key_pair, $server_key);
     }
 }
 if (!is_callable('sodium_crypto_kx_server_session_keys')) {
     /**
-     * @param string $keypair
-     * @param string $clientPublicKey
+     * @param string $server_key_pair
+     * @param string $client_key
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    function sodium_crypto_kx_server_session_keys($keypair, $clientPublicKey)
+    function sodium_crypto_kx_server_session_keys($server_key_pair, $client_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_kx_server_session_keys($keypair, $clientPublicKey);
+        return ParagonIE_Sodium_Compat::crypto_kx_server_session_keys($server_key_pair, $client_key);
     }
 }
 if (!is_callable('sodium_crypto_kx_secretkey')) {
     /**
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kx_secretkey($keypair)
+    function sodium_crypto_kx_secretkey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_kx_secretkey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_kx_secretkey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_kx_publickey')) {
     /**
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kx_publickey($keypair)
+    function sodium_crypto_kx_publickey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_kx_publickey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_kx_publickey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_pwhash')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_pwhash()
-     * @param int $outlen
+     * @param int $length
      * @param string $passwd
      * @param string $salt
      * @param int $opslimit
@@ -749,9 +793,9 @@ if (!is_callable('sodium_crypto_pwhash')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash($outlen, $passwd, $salt, $opslimit, $memlimit, $algo = null)
+    function sodium_crypto_pwhash($length, $passwd, $salt, $opslimit, $memlimit, $algo = null)
     {
-        return ParagonIE_Sodium_Compat::crypto_pwhash($outlen, $passwd, $salt, $opslimit, $memlimit, $algo);
+        return ParagonIE_Sodium_Compat::crypto_pwhash($length, $passwd, $salt, $opslimit, $memlimit, $algo);
     }
 }
 if (!is_callable('sodium_crypto_pwhash_str')) {
@@ -801,7 +845,7 @@ if (!is_callable('sodium_crypto_pwhash_str_verify')) {
 if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256()
-     * @param int $outlen
+     * @param int $length
      * @param string $passwd
      * @param string $salt
      * @param int $opslimit
@@ -810,9 +854,15 @@ if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_scryptsalsa208sha256($outlen, $passwd, $salt, $opslimit, $memlimit)
+    function sodium_crypto_pwhash_scryptsalsa208sha256($length, $passwd, $salt, $opslimit, $memlimit)
     {
-        return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256($outlen, $passwd, $salt, $opslimit, $memlimit);
+        return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256(
+            $length,
+            $passwd,
+            $salt,
+            $opslimit,
+            $memlimit
+        );
     }
 }
 if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256_str')) {
@@ -900,15 +950,15 @@ if (!is_callable('sodium_crypto_secretbox_keygen')) {
 if (!is_callable('sodium_crypto_secretbox_open')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_secretbox_open()
-     * @param string $message
+     * @param string $ciphertext
      * @param string $nonce
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_secretbox_open($message, $nonce, $key)
+    function sodium_crypto_secretbox_open($ciphertext, $nonce, $key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_secretbox_open($message, $nonce, $key);
+            return ParagonIE_Sodium_Compat::crypto_secretbox_open($ciphertext, $nonce, $key);
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -930,15 +980,24 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_init_push')) {
 if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_push')) {
     /**
      * @param string $state
-     * @param string $msg
-     * @param string $aad
+     * @param string $message
+     * @param string $additional_data
      * @param int $tag
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_push(&$state, $msg, $aad = '', $tag = 0)
-    {
-        return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_push($state, $msg, $aad, $tag);
+    function sodium_crypto_secretstream_xchacha20poly1305_push(
+        &$state,
+        $message,
+        $additional_data = '',
+        $tag = 0
+    ) {
+        return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_push(
+            $state,
+            $message,
+            $additional_data,
+            $tag
+        );
     }
 }
 if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_init_pull')) {
@@ -956,14 +1015,18 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_init_pull')) {
 if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_pull')) {
     /**
      * @param string $state
-     * @param string $cipher
-     * @param string $aad
+     * @param string $ciphertext
+     * @param string $additional_data
      * @return bool|array{0: string, 1: int}
      * @throws SodiumException
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_pull(&$state, $cipher, $aad = '')
+    function sodium_crypto_secretstream_xchacha20poly1305_pull(&$state, $ciphertext, $additional_data = '')
     {
-        return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_pull($state, $cipher, $aad);
+        return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_pull(
+            $state,
+            $ciphertext,
+            $additional_data
+        );
     }
 }
 if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_rekey')) {
@@ -1016,42 +1079,42 @@ if (!is_callable('sodium_crypto_sign')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign()
      * @param string $message
-     * @param string $sk
+     * @param string $secret_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign($message, $sk)
+    function sodium_crypto_sign($message, $secret_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign($message, $sk);
+        return ParagonIE_Sodium_Compat::crypto_sign($message, $secret_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_detached')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_detached()
      * @param string $message
-     * @param string $sk
+     * @param string $secret_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_detached($message, $sk)
+    function sodium_crypto_sign_detached($message, $secret_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_detached($message, $sk);
+        return ParagonIE_Sodium_Compat::crypto_sign_detached($message, $secret_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_keypair_from_secretkey_and_publickey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_keypair_from_secretkey_and_publickey()
-     * @param string $sk
-     * @param string $pk
+     * @param string $secret_key
+     * @param string $public_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_keypair_from_secretkey_and_publickey($sk, $pk)
+    function sodium_crypto_sign_keypair_from_secretkey_and_publickey($secret_key, $public_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_keypair_from_secretkey_and_publickey($sk, $pk);
+        return ParagonIE_Sodium_Compat::crypto_sign_keypair_from_secretkey_and_publickey($secret_key, $public_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_keypair')) {
@@ -1070,13 +1133,13 @@ if (!is_callable('sodium_crypto_sign_open')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_open()
      * @param string $signedMessage
-     * @param string $pk
+     * @param string $public_key
      * @return string|bool
      */
-    function sodium_crypto_sign_open($signedMessage, $pk)
+    function sodium_crypto_sign_open($signedMessage, $public_key)
     {
         try {
-            return ParagonIE_Sodium_Compat::crypto_sign_open($signedMessage, $pk);
+            return ParagonIE_Sodium_Compat::crypto_sign_open($signedMessage, $public_key);
         } catch (Error $ex) {
             return false;
         } catch (Exception $ex) {
@@ -1087,40 +1150,40 @@ if (!is_callable('sodium_crypto_sign_open')) {
 if (!is_callable('sodium_crypto_sign_publickey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_publickey()
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_publickey($keypair)
+    function sodium_crypto_sign_publickey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_publickey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_sign_publickey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_sign_publickey_from_secretkey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_publickey_from_secretkey()
-     * @param string $sk
+     * @param string $secret_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_publickey_from_secretkey($sk)
+    function sodium_crypto_sign_publickey_from_secretkey($secret_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_publickey_from_secretkey($sk);
+        return ParagonIE_Sodium_Compat::crypto_sign_publickey_from_secretkey($secret_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_secretkey')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_secretkey()
-     * @param string $keypair
+     * @param string $key_pair
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_secretkey($keypair)
+    function sodium_crypto_sign_secretkey($key_pair)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_secretkey($keypair);
+        return ParagonIE_Sodium_Compat::crypto_sign_secretkey($key_pair);
     }
 }
 if (!is_callable('sodium_crypto_sign_seed_keypair')) {
@@ -1141,55 +1204,55 @@ if (!is_callable('sodium_crypto_sign_verify_detached')) {
      * @see ParagonIE_Sodium_Compat::crypto_sign_verify_detached()
      * @param string $signature
      * @param string $message
-     * @param string $pk
+     * @param string $public_key
      * @return bool
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_verify_detached($signature, $message, $pk)
+    function sodium_crypto_sign_verify_detached($signature, $message, $public_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_verify_detached($signature, $message, $pk);
+        return ParagonIE_Sodium_Compat::crypto_sign_verify_detached($signature, $message, $public_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_ed25519_pk_to_curve25519')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_ed25519_pk_to_curve25519()
-     * @param string $pk
+     * @param string $public_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_ed25519_pk_to_curve25519($pk)
+    function sodium_crypto_sign_ed25519_pk_to_curve25519($public_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_ed25519_pk_to_curve25519($pk);
+        return ParagonIE_Sodium_Compat::crypto_sign_ed25519_pk_to_curve25519($public_key);
     }
 }
 if (!is_callable('sodium_crypto_sign_ed25519_sk_to_curve25519')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_sign_ed25519_sk_to_curve25519()
-     * @param string $sk
+     * @param string $secret_key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_ed25519_sk_to_curve25519($sk)
+    function sodium_crypto_sign_ed25519_sk_to_curve25519($secret_key)
     {
-        return ParagonIE_Sodium_Compat::crypto_sign_ed25519_sk_to_curve25519($sk);
+        return ParagonIE_Sodium_Compat::crypto_sign_ed25519_sk_to_curve25519($secret_key);
     }
 }
 if (!is_callable('sodium_crypto_stream')) {
     /**
      * @see ParagonIE_Sodium_Compat::crypto_stream()
-     * @param int $len
+     * @param int $length
      * @param string $nonce
      * @param string $key
      * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream($len, $nonce, $key)
+    function sodium_crypto_stream($length, $nonce, $key)
     {
-        return ParagonIE_Sodium_Compat::crypto_stream($len, $nonce, $key);
+        return ParagonIE_Sodium_Compat::crypto_stream($length, $nonce, $key);
     }
 }
 if (!is_callable('sodium_crypto_stream_keygen')) {
@@ -1278,56 +1341,56 @@ if (!is_callable('sodium_version_string')) {
 if (!is_callable('sodium_memcmp')) {
     /**
      * @see ParagonIE_Sodium_Compat::memcmp()
-     * @param string $a
-     * @param string $b
+     * @param string $string1
+     * @param string $string2
      * @return int
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_memcmp($a, $b)
+    function sodium_memcmp($string1, $string2)
     {
-        return ParagonIE_Sodium_Compat::memcmp($a, $b);
+        return ParagonIE_Sodium_Compat::memcmp($string1, $string2);
     }
 }
 if (!is_callable('sodium_memzero')) {
     /**
      * @see ParagonIE_Sodium_Compat::memzero()
-     * @param string $str
+     * @param string $string
      * @return void
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_memzero(&$str)
+    function sodium_memzero(&$string)
     {
-        ParagonIE_Sodium_Compat::memzero($str);
+        ParagonIE_Sodium_Compat::memzero($string);
     }
 }
 if (!is_callable('sodium_pad')) {
     /**
      * @see ParagonIE_Sodium_Compat::pad()
      * @param string $unpadded
-     * @param int $blockSize
-     * @return int
+     * @param int $block_size
+     * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_pad($unpadded, $blockSize)
+    function sodium_pad($unpadded, $block_size)
     {
-        return ParagonIE_Sodium_Compat::pad($unpadded, $blockSize, true);
+        return ParagonIE_Sodium_Compat::pad($unpadded, $block_size, true);
     }
 }
 if (!is_callable('sodium_unpad')) {
     /**
      * @see ParagonIE_Sodium_Compat::pad()
      * @param string $padded
-     * @param int $blockSize
-     * @return int
+     * @param int $block_size
+     * @return string
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_unpad($padded, $blockSize)
+    function sodium_unpad($padded, $block_size)
     {
-        return ParagonIE_Sodium_Compat::unpad($padded, $blockSize, true);
+        return ParagonIE_Sodium_Compat::unpad($padded, $block_size, true);
     }
 }
 if (!is_callable('sodium_randombytes_buf')) {

--- a/lib/ristretto255.php
+++ b/lib/ristretto255.php
@@ -56,26 +56,26 @@ if (!is_callable('sodium_crypto_core_ristretto255_from_hash')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_from_hash()
      *
-     * @param string $r
+     * @param string $s
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_from_hash($r)
+    function sodium_crypto_core_ristretto255_from_hash($s)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_from_hash($r, true);
+        return ParagonIE_Sodium_Compat::ristretto255_from_hash($s, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_is_valid_point')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_is_valid_point()
      *
-     * @param string $p
+     * @param string $s
      * @return bool
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_is_valid_point($p)
+    function sodium_crypto_core_ristretto255_is_valid_point($s)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_is_valid_point($p, true);
+        return ParagonIE_Sodium_Compat::ristretto255_is_valid_point($s, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_random')) {
@@ -94,27 +94,27 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_add')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_add()
      *
-     * @param string $p
-     * @param string $q
+     * @param string $x
+     * @param string $y
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_add($p, $q)
+    function sodium_crypto_core_ristretto255_scalar_add($x, $y)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_add($p, $q, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_add($x, $y, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_scalar_complement')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_complement()
      *
-     * @param string $p
+     * @param string $s
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_complement($p)
+    function sodium_crypto_core_ristretto255_scalar_complement($s)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_complement($p, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_complement($s, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_scalar_invert')) {
@@ -134,27 +134,27 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_mul')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_mul()
      *
-     * @param string $p
-     * @param string $q
+     * @param string $x
+     * @param string $y
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_mul($p, $q)
+    function sodium_crypto_core_ristretto255_scalar_mul($x, $y)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_mul($p, $q, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_mul($x, $y, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_scalar_negate')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_negate()
      *
-     * @param string $p
+     * @param string $s
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_negate($p)
+    function sodium_crypto_core_ristretto255_scalar_negate($s)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_negate($p, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_negate($s, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_scalar_random')) {
@@ -173,27 +173,27 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_reduce')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_reduce()
      *
-     * @param string $p
+     * @param string $s
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_reduce($p)
+    function sodium_crypto_core_ristretto255_scalar_reduce($s)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_reduce($p, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_reduce($s, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_scalar_sub')) {
     /**
      * @see ParagonIE_Sodium_Compat::ristretto255_scalar_sub()
      *
-     * @param string $p
-     * @param string $q
+     * @param string $x
+     * @param string $y
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_sub($p, $q)
+    function sodium_crypto_core_ristretto255_scalar_sub($x, $y)
     {
-        return ParagonIE_Sodium_Compat::ristretto255_scalar_sub($p, $q, true);
+        return ParagonIE_Sodium_Compat::ristretto255_scalar_sub($x, $y, true);
     }
 }
 if (!is_callable('sodium_crypto_core_ristretto255_sub')) {

--- a/lib/sodium_compat.php
+++ b/lib/sodium_compat.php
@@ -778,6 +778,10 @@ if (!is_callable('\\Sodium\\memzero')) {
      * @return void
      * @throws \SodiumException
      * @throws \TypeError
+     *
+     * @psalm-suppress MissingParamType
+     * @psalm-suppress MissingReturnType
+     * @psalm-suppress ReferenceConstraintViolation
      */
     function memzero(&$str)
     {

--- a/psalm-above-3.xml
+++ b/psalm-above-3.xml
@@ -4,6 +4,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="lib" />
     </projectFiles>
     <issueHandlers>
         <InvalidFunctionCall errorLevel="suppress" />

--- a/psalm-below-3.xml
+++ b/psalm-below-3.xml
@@ -3,6 +3,7 @@
     useDocblockTypes="true"
 >
     <projectFiles>
+        <directory name="lib" />
         <directory name="src" />
     </projectFiles>
     <issueHandlers>


### PR DESCRIPTION
This is technically an API break for PHP 8 projects. However, this polyfill always targeted PHP 5, 7.0, and 7.1. You shouldn't need it on 7.2+.

The end result of this change is that you should be able to write code that uses named parameters on PHP 8 and have it work regardless of ext/sodium being installed or not (provided you import sodium_compat via composer).

Additionally, we include lib/ in the psalm checks (if applicable).

This will need a new minor version (v1.19.0).