### PR TITLE
Indicates that sodium extension is provided

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "test": "phpunit"
   },
   "provide": {
+    "ext-libsodium": "*",
     "ext-sodium": "*"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
   "scripts": {
     "test": "phpunit"
   },
+  "provide": {
+    "ext-sodium": "*"
+  },
   "suggest": {
     "ext-libsodium": "PHP < 7.0: Better performance, password hashing (Argon2i), secure memory management (memzero), and better security.",
     "ext-sodium": "PHP >= 7.0: Better performance, password hashing (Argon2i), secure memory management (memzero), and better security."


### PR DESCRIPTION
Hi,

Adding the `"provide": {"ext-sodium": "*"}` will permit to install a dependency that requires this extension without actually having it installed.

This is working since version 2 of composer.

Here is an exemple of requirements checks result. I truncated it to keep only usefull information
```
$ composer check-platform-reqs            
ext-ctype            *        success provided by symfony/polyfill-ctype    
ext-curl             8.1      success
ext-mbstring         *        success provided by symfony/polyfill-mbstring 
ext-mysqli           8.1.16   success                                       
ext-sodium           n/a      lcobucci/jwt requires ext-sodium (*)      missing                                       
```

`ext-ctype` and `ext-mbstring` are not installed on the machine but checks are passing due to `provide` instructions added in https://github.com/symfony/polyfill/pull/374