### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-
-    continue-on-error: ${{ matrix.php-versions == '8.2' }}
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout
@@ -54,15 +52,8 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
-      - name: Install Composer dependencies (PHP < 8.2)
-        if: ${{ matrix.php-versions != '8.2' }}
+      - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
-
-      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.2)
-        if: ${{ matrix.php-versions == '8.2' }}
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: --ignore-platform-reqs
 
       - name: PHPUnit tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
PHP 8.2 has long been released and PHP 8.3 is nearing the first RC, so I propose adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Additional notes:
* As the build against PHP 8.3 passes, I've not added a `continue-on-error` allowance for PHP 8.3.
* As all dependencies install okay on PHP 8.3, I've removed the toggle to `composer install` with `--ignore-platform-reqs`.