### PR TITLE
Remove vendor/paragonie from box.json

### DIFF
--- a/dist/box.json
+++ b/dist/box.json
@@ -16,10 +16,6 @@
         {
             "in": "vendor/composer",
             "name": "*.php"
-        },
-        {
-            "in": "vendor/paragonie",
-            "name": "*.php"
         }
     ],
     "compactors": [


### PR DESCRIPTION
Since we no longer need random_compat, we can remove this.