### PR TITLE
[v1] Use SensitiveParameter on public API

### DIFF
--- a/lib/php72compat.php
+++ b/lib/php72compat.php
@@ -115,8 +115,12 @@ if (!is_callable('sodium_add')) {
      * @return void
      * @throws SodiumException
      */
-    function sodium_add(&$string1, $string2)
-    {
+    function sodium_add(
+        #[\SensitiveParameter]
+        &$string1,
+        #[\SensitiveParameter]
+        $string2
+    ) {
         ParagonIE_Sodium_Compat::add($string1, $string2);
     }
 }
@@ -130,8 +134,12 @@ if (!is_callable('sodium_base642bin')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_base642bin($string, $variant, $ignore ='')
-    {
+    function sodium_base642bin(
+        #[\SensitiveParameter]
+        $string,
+        $variant,
+        $ignore =''
+    ) {
         return ParagonIE_Sodium_Compat::base642bin($string, $variant, $ignore);
     }
 }
@@ -144,8 +152,11 @@ if (!is_callable('sodium_bin2base64')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_bin2base64($string, $variant)
-    {
+    function sodium_bin2base64(
+        #[\SensitiveParameter]
+        $string,
+        $variant
+    ) {
         return ParagonIE_Sodium_Compat::bin2base64($string, $variant);
     }
 }
@@ -157,8 +168,10 @@ if (!is_callable('sodium_bin2hex')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_bin2hex($string)
-    {
+    function sodium_bin2hex(
+        #[\SensitiveParameter]
+        $string
+    ) {
         return ParagonIE_Sodium_Compat::bin2hex($string);
     }
 }
@@ -171,8 +184,12 @@ if (!is_callable('sodium_compare')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_compare($string1, $string2)
-    {
+    function sodium_compare(
+        #[\SensitiveParameter]
+        $string1,
+        #[\SensitiveParameter]
+        $string2
+    ) {
         return ParagonIE_Sodium_Compat::compare($string1, $string2);
     }
 }
@@ -185,8 +202,13 @@ if (!is_callable('sodium_crypto_aead_aes256gcm_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_aes256gcm_decrypt($ciphertext, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aes256gcm_decrypt(
+        $ciphertext,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_decrypt(
                 $ciphertext,
@@ -215,8 +237,14 @@ if (!is_callable('sodium_crypto_aead_aes256gcm_encrypt')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_aes256gcm_encrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aes256gcm_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_encrypt($message, $additional_data, $nonce, $key);
     }
 }
@@ -239,8 +267,13 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_chacha20poly1305_decrypt($ciphertext, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_chacha20poly1305_decrypt(
+        $ciphertext,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_decrypt(
                 $ciphertext,
@@ -266,8 +299,14 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_encrypt')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_chacha20poly1305_encrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_chacha20poly1305_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_encrypt(
             $message,
             $additional_data,
@@ -296,8 +335,13 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_chacha20poly1305_ietf_decrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_chacha20poly1305_ietf_decrypt(
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_decrypt(
                 $message,
@@ -323,8 +367,14 @@ if (!is_callable('sodium_crypto_aead_chacha20poly1305_ietf_encrypt')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_chacha20poly1305_ietf_encrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_chacha20poly1305_ietf_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_encrypt(
             $message,
             $additional_data,
@@ -353,8 +403,13 @@ if (!is_callable('sodium_crypto_aead_xchacha20poly1305_ietf_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
+        $ciphertext,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_decrypt(
                 $ciphertext,
@@ -382,9 +437,11 @@ if (!is_callable('sodium_crypto_aead_xchacha20poly1305_ietf_encrypt')) {
      * @throws TypeError
      */
     function sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+        #[\SensitiveParameter]
         $message,
         $additional_data,
         $nonce,
+        #[\SensitiveParameter]
         $key
     ) {
         return ParagonIE_Sodium_Compat::crypto_aead_xchacha20poly1305_ietf_encrypt(
@@ -416,8 +473,11 @@ if (!is_callable('sodium_crypto_auth')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_auth($message, $key)
-    {
+    function sodium_crypto_auth(
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_auth($message, $key);
     }
 }
@@ -442,8 +502,12 @@ if (!is_callable('sodium_crypto_auth_verify')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_auth_verify($mac, $message, $key)
-    {
+    function sodium_crypto_auth_verify(
+        $mac,
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_auth_verify($mac, $message, $key);
     }
 }
@@ -457,8 +521,13 @@ if (!is_callable('sodium_crypto_box')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box($message, $nonce, $key_pair)
-    {
+    function sodium_crypto_box(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box($message, $nonce, $key_pair);
     }
 }
@@ -483,8 +552,11 @@ if (!is_callable('sodium_crypto_box_keypair_from_secretkey_and_publickey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_keypair_from_secretkey_and_publickey($secret_key, $public_key)
-    {
+    function sodium_crypto_box_keypair_from_secretkey_and_publickey(
+        #[\SensitiveParameter]
+        $secret_key,
+        $public_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_keypair_from_secretkey_and_publickey($secret_key, $public_key);
     }
 }
@@ -496,8 +568,12 @@ if (!is_callable('sodium_crypto_box_open')) {
      * @param string $key_pair
      * @return string|bool
      */
-    function sodium_crypto_box_open($ciphertext, $nonce, $key_pair)
-    {
+    function sodium_crypto_box_open(
+        $ciphertext,
+        $nonce,
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_box_open($ciphertext, $nonce, $key_pair);
         } catch (Error $ex) {
@@ -515,8 +591,10 @@ if (!is_callable('sodium_crypto_box_publickey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_publickey($key_pair)
-    {
+    function sodium_crypto_box_publickey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_publickey($key_pair);
     }
 }
@@ -528,8 +606,10 @@ if (!is_callable('sodium_crypto_box_publickey_from_secretkey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_publickey_from_secretkey($secret_key)
-    {
+    function sodium_crypto_box_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $secret_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_publickey_from_secretkey($secret_key);
     }
 }
@@ -542,8 +622,11 @@ if (!is_callable('sodium_crypto_box_seal')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_seal($message, $public_key)
-    {
+    function sodium_crypto_box_seal(
+        #[\SensitiveParameter]
+        $message,
+        $public_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_seal($message, $public_key);
     }
 }
@@ -555,8 +638,11 @@ if (!is_callable('sodium_crypto_box_seal_open')) {
      * @return string|bool
      * @throws SodiumException
      */
-    function sodium_crypto_box_seal_open($message, $key_pair)
-    {
+    function sodium_crypto_box_seal_open(
+        $message,
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_box_seal_open($message, $key_pair);
         } catch (SodiumException $ex) {
@@ -575,8 +661,10 @@ if (!is_callable('sodium_crypto_box_secretkey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_secretkey($key_pair)
-    {
+    function sodium_crypto_box_secretkey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_secretkey($key_pair);
     }
 }
@@ -588,8 +676,10 @@ if (!is_callable('sodium_crypto_box_seed_keypair')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_box_seed_keypair($seed)
-    {
+    function sodium_crypto_box_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_seed_keypair($seed);
     }
 }
@@ -603,8 +693,12 @@ if (!is_callable('sodium_crypto_generichash')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash($message, $key = null, $length = 32)
-    {
+    function sodium_crypto_generichash(
+        $message,
+        #[\SensitiveParameter]
+        $key = null,
+        $length = 32
+    ) {
         return ParagonIE_Sodium_Compat::crypto_generichash($message, $key, $length);
     }
 }
@@ -631,8 +725,11 @@ if (!is_callable('sodium_crypto_generichash_init')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash_init($key = null, $length = 32)
-    {
+    function sodium_crypto_generichash_init(
+        #[\SensitiveParameter]
+        $key = null,
+        $length = 32
+    ) {
         return ParagonIE_Sodium_Compat::crypto_generichash_init($key, $length);
     }
 }
@@ -656,8 +753,11 @@ if (!is_callable('sodium_crypto_generichash_update')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_generichash_update(&$state, $message = '')
-    {
+    function sodium_crypto_generichash_update(
+        #[\SensitiveParameter]
+        &$state,
+        $message = ''
+    ) {
         ParagonIE_Sodium_Compat::crypto_generichash_update($state, $message);
     }
 }
@@ -682,8 +782,13 @@ if (!is_callable('sodium_crypto_kdf_derive_from_key')) {
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kdf_derive_from_key($subkey_length, $subkey_id, $context, $key)
-    {
+    function sodium_crypto_kdf_derive_from_key(
+        $subkey_length,
+        $subkey_id,
+        $context,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kdf_derive_from_key(
             $subkey_length,
             $subkey_id,
@@ -703,8 +808,13 @@ if (!is_callable('sodium_crypto_kx')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_kx($my_secret, $their_public, $client_public, $server_public)
-    {
+    function sodium_crypto_kx(
+        #[\SensitiveParameter]
+        $my_secret,
+        $their_public,
+        $client_public,
+        $server_public
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx(
             $my_secret,
             $their_public,
@@ -719,8 +829,10 @@ if (!is_callable('sodium_crypto_kx_seed_keypair')) {
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kx_seed_keypair($seed)
-    {
+    function sodium_crypto_kx_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx_seed_keypair($seed);
     }
 }
@@ -741,8 +853,11 @@ if (!is_callable('sodium_crypto_kx_client_session_keys')) {
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    function sodium_crypto_kx_client_session_keys($client_key_pair, $server_key)
-    {
+    function sodium_crypto_kx_client_session_keys(
+        #[\SensitiveParameter]
+        $client_key_pair,
+        $server_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx_client_session_keys($client_key_pair, $server_key);
     }
 }
@@ -753,8 +868,11 @@ if (!is_callable('sodium_crypto_kx_server_session_keys')) {
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    function sodium_crypto_kx_server_session_keys($server_key_pair, $client_key)
-    {
+    function sodium_crypto_kx_server_session_keys(
+        #[\SensitiveParameter]
+        $server_key_pair,
+        $client_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx_server_session_keys($server_key_pair, $client_key);
     }
 }
@@ -764,8 +882,10 @@ if (!is_callable('sodium_crypto_kx_secretkey')) {
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kx_secretkey($key_pair)
-    {
+    function sodium_crypto_kx_secretkey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx_secretkey($key_pair);
     }
 }
@@ -775,8 +895,10 @@ if (!is_callable('sodium_crypto_kx_publickey')) {
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_kx_publickey($key_pair)
-    {
+    function sodium_crypto_kx_publickey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx_publickey($key_pair);
     }
 }
@@ -793,8 +915,15 @@ if (!is_callable('sodium_crypto_pwhash')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash($length, $passwd, $salt, $opslimit, $memlimit, $algo = null)
-    {
+    function sodium_crypto_pwhash(
+        $length,
+        #[\SensitiveParameter]
+        $passwd,
+        $salt,
+        $opslimit,
+        $memlimit,
+        $algo = null
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash($length, $passwd, $salt, $opslimit, $memlimit, $algo);
     }
 }
@@ -808,8 +937,12 @@ if (!is_callable('sodium_crypto_pwhash_str')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_str($passwd, $opslimit, $memlimit)
-    {
+    function sodium_crypto_pwhash_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_str($passwd, $opslimit, $memlimit);
     }
 }
@@ -823,8 +956,12 @@ if (!is_callable('sodium_crypto_pwhash_str_needs_rehash')) {
      *
      * @throws SodiumException
      */
-    function sodium_crypto_pwhash_str_needs_rehash($hash, $opslimit, $memlimit)
-    {
+    function sodium_crypto_pwhash_str_needs_rehash(
+        #[\SensitiveParameter]
+        $hash,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_str_needs_rehash($hash, $opslimit, $memlimit);
     }
 }
@@ -837,8 +974,12 @@ if (!is_callable('sodium_crypto_pwhash_str_verify')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_str_verify($passwd, $hash)
-    {
+    function sodium_crypto_pwhash_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_str_verify($passwd, $hash);
     }
 }
@@ -854,8 +995,14 @@ if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_scryptsalsa208sha256($length, $passwd, $salt, $opslimit, $memlimit)
-    {
+    function sodium_crypto_pwhash_scryptsalsa208sha256(
+        $length,
+        #[\SensitiveParameter]
+        $passwd,
+        $salt,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256(
             $length,
             $passwd,
@@ -875,8 +1022,12 @@ if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256_str')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_scryptsalsa208sha256_str($passwd, $opslimit, $memlimit)
-    {
+    function sodium_crypto_pwhash_scryptsalsa208sha256_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256_str($passwd, $opslimit, $memlimit);
     }
 }
@@ -889,8 +1040,12 @@ if (!is_callable('sodium_crypto_pwhash_scryptsalsa208sha256_str_verify')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_pwhash_scryptsalsa208sha256_str_verify($passwd, $hash)
-    {
+    function sodium_crypto_pwhash_scryptsalsa208sha256_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256_str_verify($passwd, $hash);
     }
 }
@@ -903,8 +1058,11 @@ if (!is_callable('sodium_crypto_scalarmult')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_scalarmult($n, $p)
-    {
+    function sodium_crypto_scalarmult(
+        #[\SensitiveParameter]
+        $n,
+        $p
+    ) {
         return ParagonIE_Sodium_Compat::crypto_scalarmult($n, $p);
     }
 }
@@ -916,8 +1074,10 @@ if (!is_callable('sodium_crypto_scalarmult_base')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_scalarmult_base($n)
-    {
+    function sodium_crypto_scalarmult_base(
+        #[\SensitiveParameter]
+        $n
+    ) {
         return ParagonIE_Sodium_Compat::crypto_scalarmult_base($n);
     }
 }
@@ -931,8 +1091,13 @@ if (!is_callable('sodium_crypto_secretbox')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_secretbox($message, $nonce, $key)
-    {
+    function sodium_crypto_secretbox(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_secretbox($message, $nonce, $key);
     }
 }
@@ -955,8 +1120,12 @@ if (!is_callable('sodium_crypto_secretbox_open')) {
      * @param string $key
      * @return string|bool
      */
-    function sodium_crypto_secretbox_open($ciphertext, $nonce, $key)
-    {
+    function sodium_crypto_secretbox_open(
+        $ciphertext,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_secretbox_open($ciphertext, $nonce, $key);
         } catch (Error $ex) {
@@ -972,8 +1141,10 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_init_push')) {
      * @return array<int, string>
      * @throws SodiumException
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_init_push($key)
-    {
+    function sodium_crypto_secretstream_xchacha20poly1305_init_push(
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_init_push($key);
     }
 }
@@ -987,7 +1158,9 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_push')) {
      * @throws SodiumException
      */
     function sodium_crypto_secretstream_xchacha20poly1305_push(
+        #[\SensitiveParameter]
         &$state,
+        #[\SensitiveParameter]
         $message,
         $additional_data = '',
         $tag = 0
@@ -1007,8 +1180,11 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_init_pull')) {
      * @return string
      * @throws Exception
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_init_pull($header, $key)
-    {
+    function sodium_crypto_secretstream_xchacha20poly1305_init_pull(
+        $header,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_init_pull($header, $key);
     }
 }
@@ -1020,8 +1196,12 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_pull')) {
      * @return bool|array{0: string, 1: int}
      * @throws SodiumException
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_pull(&$state, $ciphertext, $additional_data = '')
-    {
+    function sodium_crypto_secretstream_xchacha20poly1305_pull(
+        #[\SensitiveParameter]
+        &$state,
+        $ciphertext,
+        $additional_data = ''
+    ) {
         return ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_pull(
             $state,
             $ciphertext,
@@ -1035,8 +1215,10 @@ if (!is_callable('sodium_crypto_secretstream_xchacha20poly1305_rekey')) {
      * @return void
      * @throws SodiumException
      */
-    function sodium_crypto_secretstream_xchacha20poly1305_rekey(&$state)
-    {
+    function sodium_crypto_secretstream_xchacha20poly1305_rekey(
+        #[\SensitiveParameter]
+        &$state
+    ) {
         ParagonIE_Sodium_Compat::crypto_secretstream_xchacha20poly1305_rekey($state);
     }
 }
@@ -1059,8 +1241,11 @@ if (!is_callable('sodium_crypto_shorthash')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_shorthash($message, $key = '')
-    {
+    function sodium_crypto_shorthash(
+        $message,
+        #[\SensitiveParameter]
+        $key = ''
+    ) {
         return ParagonIE_Sodium_Compat::crypto_shorthash($message, $key);
     }
 }
@@ -1084,8 +1269,11 @@ if (!is_callable('sodium_crypto_sign')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign($message, $secret_key)
-    {
+    function sodium_crypto_sign(
+        $message,
+        #[\SensitiveParameter]
+        $secret_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign($message, $secret_key);
     }
 }
@@ -1098,8 +1286,11 @@ if (!is_callable('sodium_crypto_sign_detached')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_detached($message, $secret_key)
-    {
+    function sodium_crypto_sign_detached(
+        $message,
+        #[\SensitiveParameter]
+        $secret_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_detached($message, $secret_key);
     }
 }
@@ -1112,8 +1303,11 @@ if (!is_callable('sodium_crypto_sign_keypair_from_secretkey_and_publickey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_keypair_from_secretkey_and_publickey($secret_key, $public_key)
-    {
+    function sodium_crypto_sign_keypair_from_secretkey_and_publickey(
+        #[\SensitiveParameter]
+        $secret_key,
+        $public_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_keypair_from_secretkey_and_publickey($secret_key, $public_key);
     }
 }
@@ -1155,8 +1349,10 @@ if (!is_callable('sodium_crypto_sign_publickey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_publickey($key_pair)
-    {
+    function sodium_crypto_sign_publickey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_publickey($key_pair);
     }
 }
@@ -1168,8 +1364,10 @@ if (!is_callable('sodium_crypto_sign_publickey_from_secretkey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_publickey_from_secretkey($secret_key)
-    {
+    function sodium_crypto_sign_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $secret_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_publickey_from_secretkey($secret_key);
     }
 }
@@ -1181,8 +1379,10 @@ if (!is_callable('sodium_crypto_sign_secretkey')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_secretkey($key_pair)
-    {
+    function sodium_crypto_sign_secretkey(
+        #[\SensitiveParameter]
+        $key_pair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_secretkey($key_pair);
     }
 }
@@ -1194,8 +1394,10 @@ if (!is_callable('sodium_crypto_sign_seed_keypair')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_seed_keypair($seed)
-    {
+    function sodium_crypto_sign_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_seed_keypair($seed);
     }
 }
@@ -1235,8 +1437,10 @@ if (!is_callable('sodium_crypto_sign_ed25519_sk_to_curve25519')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_sign_ed25519_sk_to_curve25519($secret_key)
-    {
+    function sodium_crypto_sign_ed25519_sk_to_curve25519(
+        #[\SensitiveParameter]
+        $secret_key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_ed25519_sk_to_curve25519($secret_key);
     }
 }
@@ -1250,8 +1454,12 @@ if (!is_callable('sodium_crypto_stream')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream($length, $nonce, $key)
-    {
+    function sodium_crypto_stream(
+        $length,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream($length, $nonce, $key);
     }
 }
@@ -1276,8 +1484,13 @@ if (!is_callable('sodium_crypto_stream_xor')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream_xor($message, $nonce, $key)
-    {
+    function sodium_crypto_stream_xor(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream_xor($message, $nonce, $key);
     }
 }
@@ -1291,8 +1504,11 @@ if (!is_callable('sodium_hex2bin')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_hex2bin($string, $ignore = '')
-    {
+    function sodium_hex2bin(
+        #[\SensitiveParameter]
+        $string,
+        $ignore = ''
+    ) {
         return ParagonIE_Sodium_Compat::hex2bin($string, $ignore);
     }
 }
@@ -1304,8 +1520,10 @@ if (!is_callable('sodium_increment')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_increment(&$string)
-    {
+    function sodium_increment(
+        #[\SensitiveParameter]
+        &$string
+    ) {
         ParagonIE_Sodium_Compat::increment($string);
     }
 }
@@ -1348,8 +1566,12 @@ if (!is_callable('sodium_memcmp')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_memcmp($string1, $string2)
-    {
+    function sodium_memcmp(
+        #[\SensitiveParameter]
+        $string1,
+        #[\SensitiveParameter]
+        $string2
+    ) {
         return ParagonIE_Sodium_Compat::memcmp($string1, $string2);
     }
 }
@@ -1363,8 +1585,10 @@ if (!is_callable('sodium_memzero')) {
      *
      * @psalm-suppress ReferenceConstraintViolation
      */
-    function sodium_memzero(&$string)
-    {
+    function sodium_memzero(
+        #[\SensitiveParameter]
+        &$string
+    ) {
         ParagonIE_Sodium_Compat::memzero($string);
     }
 }
@@ -1377,8 +1601,11 @@ if (!is_callable('sodium_pad')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_pad($unpadded, $block_size)
-    {
+    function sodium_pad(
+        #[\SensitiveParameter]
+        $unpadded,
+        $block_size
+    ) {
         return ParagonIE_Sodium_Compat::pad($unpadded, $block_size, true);
     }
 }
@@ -1391,8 +1618,11 @@ if (!is_callable('sodium_unpad')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_unpad($padded, $block_size)
-    {
+    function sodium_unpad(
+        #[\SensitiveParameter]
+        $padded,
+        $block_size
+    ) {
         return ParagonIE_Sodium_Compat::unpad($padded, $block_size, true);
     }
 }

--- a/lib/php84compat.php
+++ b/lib/php84compat.php
@@ -34,8 +34,13 @@ if (!is_callable('sodium_crypto_aead_aegis128l_decrypt')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_aead_aegis128l_decrypt($ciphertext, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aegis128l_decrypt(
+        $ciphertext,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aegis128l_decrypt(
             $ciphertext,
             $additional_data,
@@ -55,8 +60,14 @@ if (!is_callable('sodium_crypto_aead_aegis128l_encrypt')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_aegis128l_encrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aegis128l_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aegis128l_encrypt(
             $message,
             $additional_data,
@@ -75,8 +86,13 @@ if (!is_callable('sodium_crypto_aead_aegis256_decrypt')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_aead_aegis256_decrypt($ciphertext, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aegis256_decrypt(
+        $ciphertext,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aegis256_decrypt(
             $ciphertext,
             $additional_data,
@@ -96,8 +112,14 @@ if (!is_callable('sodium_crypto_aead_aegis256_encrypt')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_aead_aegis256_encrypt($message, $additional_data, $nonce, $key)
-    {
+    function sodium_crypto_aead_aegis256_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $additional_data,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aegis256_encrypt(
             $message,
             $additional_data,

--- a/lib/ristretto255.php
+++ b/lib/ristretto255.php
@@ -47,8 +47,12 @@ if (!is_callable('sodium_crypto_core_ristretto255_add')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_add($p, $q)
-    {
+    function sodium_crypto_core_ristretto255_add(
+        #[\SensitiveParameter]
+        $p,
+        #[\SensitiveParameter]
+        $q
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_add($p, $q, true);
     }
 }
@@ -60,8 +64,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_from_hash')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_from_hash($s)
-    {
+    function sodium_crypto_core_ristretto255_from_hash(
+        #[\SensitiveParameter]
+        $s
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_from_hash($s, true);
     }
 }
@@ -73,8 +79,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_is_valid_point')) {
      * @return bool
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_is_valid_point($s)
-    {
+    function sodium_crypto_core_ristretto255_is_valid_point(
+        #[\SensitiveParameter]
+        $s
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_is_valid_point($s, true);
     }
 }
@@ -99,8 +107,12 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_add')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_add($x, $y)
-    {
+    function sodium_crypto_core_ristretto255_scalar_add(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_add($x, $y, true);
     }
 }
@@ -112,8 +124,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_complement')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_complement($s)
-    {
+    function sodium_crypto_core_ristretto255_scalar_complement(
+        #[\SensitiveParameter]
+        $s
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_complement($s, true);
     }
 }
@@ -125,8 +139,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_invert')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_invert($p)
-    {
+    function sodium_crypto_core_ristretto255_scalar_invert(
+        #[\SensitiveParameter]
+        $p
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_invert($p, true);
     }
 }
@@ -139,8 +155,12 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_mul')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_mul($x, $y)
-    {
+    function sodium_crypto_core_ristretto255_scalar_mul(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_mul($x, $y, true);
     }
 }
@@ -152,8 +172,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_negate')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_negate($s)
-    {
+    function sodium_crypto_core_ristretto255_scalar_negate(
+        #[\SensitiveParameter]
+        $s
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_negate($s, true);
     }
 }
@@ -177,8 +199,10 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_reduce')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_reduce($s)
-    {
+    function sodium_crypto_core_ristretto255_scalar_reduce(
+        #[\SensitiveParameter]
+        $s
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_reduce($s, true);
     }
 }
@@ -191,8 +215,12 @@ if (!is_callable('sodium_crypto_core_ristretto255_scalar_sub')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_scalar_sub($x, $y)
-    {
+    function sodium_crypto_core_ristretto255_scalar_sub(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_scalar_sub($x, $y, true);
     }
 }
@@ -205,8 +233,12 @@ if (!is_callable('sodium_crypto_core_ristretto255_sub')) {
      * @return string
      * @throws SodiumException
      */
-    function sodium_crypto_core_ristretto255_sub($p, $q)
-    {
+    function sodium_crypto_core_ristretto255_sub(
+        #[\SensitiveParameter]
+        $p,
+        #[\SensitiveParameter]
+        $q
+    ) {
         return ParagonIE_Sodium_Compat::ristretto255_sub($p, $q, true);
     }
 }
@@ -219,8 +251,12 @@ if (!is_callable('sodium_crypto_scalarmult_ristretto255')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_scalarmult_ristretto255($n, $p)
-    {
+    function sodium_crypto_scalarmult_ristretto255(
+        #[\SensitiveParameter]
+        $n,
+        #[\SensitiveParameter]
+        $p
+    ) {
         return ParagonIE_Sodium_Compat::scalarmult_ristretto255($n, $p, true);
     }
 }
@@ -232,8 +268,10 @@ if (!is_callable('sodium_crypto_scalarmult_ristretto255_base')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_scalarmult_ristretto255_base($n)
-    {
+    function sodium_crypto_scalarmult_ristretto255_base(
+        #[\SensitiveParameter]
+        $n
+    ) {
         return ParagonIE_Sodium_Compat::scalarmult_ristretto255_base($n, true);
     }
 }

--- a/lib/sodium_compat.php
+++ b/lib/sodium_compat.php
@@ -20,8 +20,10 @@ if (!is_callable('\\Sodium\\bin2hex')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function bin2hex($string)
-    {
+    function bin2hex(
+        #[\SensitiveParameter]
+        $string
+    ) {
         return ParagonIE_Sodium_Compat::bin2hex($string);
     }
 }
@@ -34,8 +36,12 @@ if (!is_callable('\\Sodium\\compare')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function compare($a, $b)
-    {
+    function compare(
+        #[\SensitiveParameter]
+        $a,
+        #[\SensitiveParameter]
+        $b
+    ) {
         return ParagonIE_Sodium_Compat::compare($a, $b);
     }
 }
@@ -48,8 +54,13 @@ if (!is_callable('\\Sodium\\crypto_aead_aes256gcm_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function crypto_aead_aes256gcm_decrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_aes256gcm_decrypt(
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_decrypt($message, $assocData, $nonce, $key);
         } catch (\TypeError $ex) {
@@ -70,8 +81,14 @@ if (!is_callable('\\Sodium\\crypto_aead_aes256gcm_encrypt')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_aead_aes256gcm_encrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_aes256gcm_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_aes256gcm_encrypt($message, $assocData, $nonce, $key);
     }
 }
@@ -94,8 +111,13 @@ if (!is_callable('\\Sodium\\crypto_aead_chacha20poly1305_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function crypto_aead_chacha20poly1305_decrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_chacha20poly1305_decrypt(
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_decrypt($message, $assocData, $nonce, $key);
         } catch (\TypeError $ex) {
@@ -116,8 +138,14 @@ if (!is_callable('\\Sodium\\crypto_aead_chacha20poly1305_encrypt')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_aead_chacha20poly1305_encrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_chacha20poly1305_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_encrypt($message, $assocData, $nonce, $key);
     }
 }
@@ -130,8 +158,13 @@ if (!is_callable('\\Sodium\\crypto_aead_chacha20poly1305_ietf_decrypt')) {
      * @param string $key
      * @return string|bool
      */
-    function crypto_aead_chacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_chacha20poly1305_ietf_decrypt(
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_decrypt($message, $assocData, $nonce, $key);
         } catch (\TypeError $ex) {
@@ -152,8 +185,14 @@ if (!is_callable('\\Sodium\\crypto_aead_chacha20poly1305_ietf_encrypt')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_aead_chacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key)
-    {
+    function crypto_aead_chacha20poly1305_ietf_encrypt(
+        #[\SensitiveParameter]
+        $message,
+        $assocData,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_aead_chacha20poly1305_ietf_encrypt($message, $assocData, $nonce, $key);
     }
 }
@@ -166,8 +205,11 @@ if (!is_callable('\\Sodium\\crypto_auth')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_auth($message, $key)
-    {
+    function crypto_auth(
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_auth($message, $key);
     }
 }
@@ -181,8 +223,12 @@ if (!is_callable('\\Sodium\\crypto_auth_verify')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_auth_verify($mac, $message, $key)
-    {
+    function crypto_auth_verify(
+        $mac,
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_auth_verify($mac, $message, $key);
     }
 }
@@ -196,8 +242,13 @@ if (!is_callable('\\Sodium\\crypto_box')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box($message, $nonce, $kp)
-    {
+    function crypto_box(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $kp
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box($message, $nonce, $kp);
     }
 }
@@ -222,8 +273,11 @@ if (!is_callable('\\Sodium\\crypto_box_keypair_from_secretkey_and_publickey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box_keypair_from_secretkey_and_publickey($sk, $pk)
-    {
+    function crypto_box_keypair_from_secretkey_and_publickey(
+        #[\SensitiveParameter]
+        $sk,
+        $pk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_keypair_from_secretkey_and_publickey($sk, $pk);
     }
 }
@@ -235,8 +289,13 @@ if (!is_callable('\\Sodium\\crypto_box_open')) {
      * @param string $kp
      * @return string|bool
      */
-    function crypto_box_open($message, $nonce, $kp)
-    {
+    function crypto_box_open(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $kp
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_box_open($message, $nonce, $kp);
         } catch (\TypeError $ex) {
@@ -254,8 +313,10 @@ if (!is_callable('\\Sodium\\crypto_box_publickey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box_publickey($keypair)
-    {
+    function crypto_box_publickey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_publickey($keypair);
     }
 }
@@ -267,8 +328,10 @@ if (!is_callable('\\Sodium\\crypto_box_publickey_from_secretkey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box_publickey_from_secretkey($sk)
-    {
+    function crypto_box_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $sk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_publickey_from_secretkey($sk);
     }
 }
@@ -281,8 +344,11 @@ if (!is_callable('\\Sodium\\crypto_box_seal')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box_seal($message, $publicKey)
-    {
+    function crypto_box_seal(
+        #[\SensitiveParameter]
+        $message,
+        $publicKey
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_seal($message, $publicKey);
     }
 }
@@ -293,8 +359,11 @@ if (!is_callable('\\Sodium\\crypto_box_seal_open')) {
      * @param string $kp
      * @return string|bool
      */
-    function crypto_box_seal_open($message, $kp)
-    {
+    function crypto_box_seal_open(
+        $message,
+        #[\SensitiveParameter]
+        $kp
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_box_seal_open($message, $kp);
         } catch (\TypeError $ex) {
@@ -312,8 +381,10 @@ if (!is_callable('\\Sodium\\crypto_box_secretkey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_box_secretkey($keypair)
-    {
+    function crypto_box_secretkey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_box_secretkey($keypair);
     }
 }
@@ -327,8 +398,12 @@ if (!is_callable('\\Sodium\\crypto_generichash')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_generichash($message, $key = null, $outLen = 32)
-    {
+    function crypto_generichash(
+        $message,
+        #[\SensitiveParameter]
+        $key = null,
+        $outLen = 32
+    ) {
         return ParagonIE_Sodium_Compat::crypto_generichash($message, $key, $outLen);
     }
 }
@@ -341,8 +416,11 @@ if (!is_callable('\\Sodium\\crypto_generichash_final')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_generichash_final(&$ctx, $outputLength = 32)
-    {
+    function crypto_generichash_final(
+        #[\SensitiveParameter]
+        &$ctx,
+        $outputLength = 32
+    ) {
         return ParagonIE_Sodium_Compat::crypto_generichash_final($ctx, $outputLength);
     }
 }
@@ -355,8 +433,11 @@ if (!is_callable('\\Sodium\\crypto_generichash_init')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_generichash_init($key = null, $outLen = 32)
-    {
+    function crypto_generichash_init(
+        #[\SensitiveParameter]
+        $key = null,
+        $outLen = 32
+    ) {
         return ParagonIE_Sodium_Compat::crypto_generichash_init($key, $outLen);
     }
 }
@@ -369,8 +450,11 @@ if (!is_callable('\\Sodium\\crypto_generichash_update')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_generichash_update(&$ctx, $message = '')
-    {
+    function crypto_generichash_update(
+        #[\SensitiveParameter]
+        &$ctx,
+        $message = ''
+    ) {
         ParagonIE_Sodium_Compat::crypto_generichash_update($ctx, $message);
     }
 }
@@ -385,8 +469,13 @@ if (!is_callable('\\Sodium\\crypto_kx')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_kx($my_secret, $their_public, $client_public, $server_public)
-    {
+    function crypto_kx(
+        #[\SensitiveParameter]
+        $my_secret,
+        $their_public,
+        $client_public,
+        $server_public
+    ) {
         return ParagonIE_Sodium_Compat::crypto_kx(
             $my_secret,
             $their_public,
@@ -408,8 +497,14 @@ if (!is_callable('\\Sodium\\crypto_pwhash')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash($outlen, $passwd, $salt, $opslimit, $memlimit)
-    {
+    function crypto_pwhash(
+        $outlen,
+        #[\SensitiveParameter]
+        $passwd,
+        $salt,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash($outlen, $passwd, $salt, $opslimit, $memlimit);
     }
 }
@@ -423,8 +518,12 @@ if (!is_callable('\\Sodium\\crypto_pwhash_str')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash_str($passwd, $opslimit, $memlimit)
-    {
+    function crypto_pwhash_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_str($passwd, $opslimit, $memlimit);
     }
 }
@@ -437,8 +536,12 @@ if (!is_callable('\\Sodium\\crypto_pwhash_str_verify')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash_str_verify($passwd, $hash)
-    {
+    function crypto_pwhash_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_str_verify($passwd, $hash);
     }
 }
@@ -454,8 +557,15 @@ if (!is_callable('\\Sodium\\crypto_pwhash_scryptsalsa208sha256')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash_scryptsalsa208sha256($outlen, $passwd, $salt, $opslimit, $memlimit)
-    {
+    function crypto_pwhash_scryptsalsa208sha256(
+        $outlen,
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $salt,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256($outlen, $passwd, $salt, $opslimit, $memlimit);
     }
 }
@@ -469,8 +579,12 @@ if (!is_callable('\\Sodium\\crypto_pwhash_scryptsalsa208sha256_str')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash_scryptsalsa208sha256_str($passwd, $opslimit, $memlimit)
-    {
+    function crypto_pwhash_scryptsalsa208sha256_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256_str($passwd, $opslimit, $memlimit);
     }
 }
@@ -483,8 +597,12 @@ if (!is_callable('\\Sodium\\crypto_pwhash_scryptsalsa208sha256_str_verify')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_pwhash_scryptsalsa208sha256_str_verify($passwd, $hash)
-    {
+    function crypto_pwhash_scryptsalsa208sha256_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         return ParagonIE_Sodium_Compat::crypto_pwhash_scryptsalsa208sha256_str_verify($passwd, $hash);
     }
 }
@@ -497,8 +615,11 @@ if (!is_callable('\\Sodium\\crypto_scalarmult')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_scalarmult($n, $p)
-    {
+    function crypto_scalarmult(
+        #[\SensitiveParameter]
+        $n,
+        $p
+    ) {
         return ParagonIE_Sodium_Compat::crypto_scalarmult($n, $p);
     }
 }
@@ -510,8 +631,10 @@ if (!is_callable('\\Sodium\\crypto_scalarmult_base')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_scalarmult_base($n)
-    {
+    function crypto_scalarmult_base(
+        #[\SensitiveParameter]
+        $n
+    ) {
         return ParagonIE_Sodium_Compat::crypto_scalarmult_base($n);
     }
 }
@@ -525,8 +648,13 @@ if (!is_callable('\\Sodium\\crypto_secretbox')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_secretbox($message, $nonce, $key)
-    {
+    function crypto_secretbox(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_secretbox($message, $nonce, $key);
     }
 }
@@ -538,8 +666,12 @@ if (!is_callable('\\Sodium\\crypto_secretbox_open')) {
      * @param string $key
      * @return string|bool
      */
-    function crypto_secretbox_open($message, $nonce, $key)
-    {
+    function crypto_secretbox_open(
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         try {
             return ParagonIE_Sodium_Compat::crypto_secretbox_open($message, $nonce, $key);
         } catch (\TypeError $ex) {
@@ -558,8 +690,11 @@ if (!is_callable('\\Sodium\\crypto_shorthash')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_shorthash($message, $key = '')
-    {
+    function crypto_shorthash(
+        $message,
+        #[\SensitiveParameter]
+        $key = ''
+    ) {
         return ParagonIE_Sodium_Compat::crypto_shorthash($message, $key);
     }
 }
@@ -572,8 +707,11 @@ if (!is_callable('\\Sodium\\crypto_sign')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign($message, $sk)
-    {
+    function crypto_sign(
+        $message,
+        #[\SensitiveParameter]
+        $sk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign($message, $sk);
     }
 }
@@ -586,8 +724,11 @@ if (!is_callable('\\Sodium\\crypto_sign_detached')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_detached($message, $sk)
-    {
+    function crypto_sign_detached(
+        $message,
+        #[\SensitiveParameter]
+        $sk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_detached($message, $sk);
     }
 }
@@ -629,8 +770,10 @@ if (!is_callable('\\Sodium\\crypto_sign_publickey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_publickey($keypair)
-    {
+    function crypto_sign_publickey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_publickey($keypair);
     }
 }
@@ -642,8 +785,10 @@ if (!is_callable('\\Sodium\\crypto_sign_publickey_from_secretkey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_publickey_from_secretkey($sk)
-    {
+    function crypto_sign_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $sk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_publickey_from_secretkey($sk);
     }
 }
@@ -655,8 +800,10 @@ if (!is_callable('\\Sodium\\crypto_sign_secretkey')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_secretkey($keypair)
-    {
+    function crypto_sign_secretkey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_secretkey($keypair);
     }
 }
@@ -668,8 +815,10 @@ if (!is_callable('\\Sodium\\crypto_sign_seed_keypair')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_seed_keypair($seed)
-    {
+    function crypto_sign_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_seed_keypair($seed);
     }
 }
@@ -709,8 +858,10 @@ if (!is_callable('\\Sodium\\crypto_sign_ed25519_sk_to_curve25519')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_sign_ed25519_sk_to_curve25519($sk)
-    {
+    function crypto_sign_ed25519_sk_to_curve25519(
+        #[\SensitiveParameter]
+        $sk
+    ) {
         return ParagonIE_Sodium_Compat::crypto_sign_ed25519_sk_to_curve25519($sk);
     }
 }
@@ -724,8 +875,12 @@ if (!is_callable('\\Sodium\\crypto_stream')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_stream($len, $nonce, $key)
-    {
+    function crypto_stream(
+        $len,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream($len, $nonce, $key);
     }
 }
@@ -739,8 +894,13 @@ if (!is_callable('\\Sodium\\crypto_stream_xor')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function crypto_stream_xor($message, $nonce, $key)
-    {
+    function crypto_stream_xor(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream_xor($message, $nonce, $key);
     }
 }
@@ -752,8 +912,10 @@ if (!is_callable('\\Sodium\\hex2bin')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function hex2bin($string)
-    {
+    function hex2bin(
+        #[\SensitiveParameter]
+        $string
+    ) {
         return ParagonIE_Sodium_Compat::hex2bin($string);
     }
 }
@@ -766,8 +928,12 @@ if (!is_callable('\\Sodium\\memcmp')) {
      * @throws \SodiumException
      * @throws \TypeError
      */
-    function memcmp($a, $b)
-    {
+    function memcmp(
+        #[\SensitiveParameter]
+        $a,
+        #[\SensitiveParameter]
+        $b
+    ) {
         return ParagonIE_Sodium_Compat::memcmp($a, $b);
     }
 }
@@ -783,8 +949,10 @@ if (!is_callable('\\Sodium\\memzero')) {
      * @psalm-suppress MissingReturnType
      * @psalm-suppress ReferenceConstraintViolation
      */
-    function memzero(&$str)
-    {
+    function memzero(
+        #[\SensitiveParameter]
+        &$str
+    ) {
         ParagonIE_Sodium_Compat::memzero($str);
     }
 }

--- a/lib/stream-xchacha20.php
+++ b/lib/stream-xchacha20.php
@@ -10,8 +10,12 @@ if (!is_callable('sodium_crypto_stream_xchacha20')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream_xchacha20($len, $nonce, $key)
-    {
+    function sodium_crypto_stream_xchacha20(
+        $len,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream_xchacha20($len, $nonce, $key, true);
     }
 }
@@ -36,8 +40,13 @@ if (!is_callable('sodium_crypto_stream_xchacha20_xor')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream_xchacha20_xor($message, $nonce, $key)
-    {
+    function sodium_crypto_stream_xchacha20_xor(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream_xchacha20_xor($message, $nonce, $key, true);
     }
 }
@@ -52,8 +61,14 @@ if (!is_callable('sodium_crypto_stream_xchacha20_xor_ic')) {
      * @throws SodiumException
      * @throws TypeError
      */
-    function sodium_crypto_stream_xchacha20_xor_ic($message, $nonce, $counter, $key)
-    {
+    function sodium_crypto_stream_xchacha20_xor_ic(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        $counter,
+        #[\SensitiveParameter]
+        $key
+    ) {
         return ParagonIE_Sodium_Compat::crypto_stream_xchacha20_xor_ic($message, $nonce, $counter, $key, true);
     }
 }

--- a/src/Compat.php
+++ b/src/Compat.php
@@ -163,8 +163,12 @@ class ParagonIE_Sodium_Compat
      * @return void
      * @throws SodiumException
      */
-    public static function add(&$val, $addv)
-    {
+    public static function add(
+        #[\SensitiveParameter]
+        &$val,
+        #[\SensitiveParameter]
+        $addv
+    ) {
         $val_len = ParagonIE_Sodium_Core_Util::strlen($val);
         $addv_len = ParagonIE_Sodium_Core_Util::strlen($addv);
         if ($val_len !== $addv_len) {
@@ -189,8 +193,12 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function base642bin($encoded, $variant, $ignore = '')
-    {
+    public static function base642bin(
+        #[\SensitiveParameter]
+        $encoded,
+        $variant,
+        $ignore = ''
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($encoded, 'string', 1);
 
@@ -232,8 +240,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function bin2base64($decoded, $variant)
-    {
+    public static function bin2base64(
+        #[\SensitiveParameter]
+        $decoded,
+        $variant
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($decoded, 'string', 1);
         /** @var string $decoded */
@@ -265,8 +276,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function bin2hex($string)
-    {
+    public static function bin2hex(
+        #[\SensitiveParameter]
+        $string
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($string, 'string', 1);
 
@@ -292,8 +305,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function compare($left, $right)
-    {
+    public static function compare(
+        #[\SensitiveParameter]
+        $left,
+        #[\SensitiveParameter]
+        $right
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($left, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($right, 'string', 2);
@@ -329,6 +346,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
@@ -378,9 +396,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_aegis128l_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($plaintext, 'string', 1);
@@ -435,6 +455,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
@@ -484,9 +505,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_aegis256_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($plaintext, 'string', 1);
@@ -571,6 +594,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         if (!self::crypto_aead_aes256gcm_is_available()) {
@@ -628,9 +652,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_aes256gcm_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         if (!self::crypto_aead_aes256gcm_is_available()) {
@@ -704,6 +730,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         /* Type checks: */
@@ -781,9 +808,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_chacha20poly1305_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         /* Type checks: */
@@ -858,6 +887,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         /* Type checks: */
@@ -948,9 +978,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_chacha20poly1305_ietf_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = ''
     ) {
         /* Type checks: */
@@ -1039,6 +1071,7 @@ class ParagonIE_Sodium_Compat
         $ciphertext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = '',
         $dontFallback = false
     ) {
@@ -1111,9 +1144,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_aead_xchacha20poly1305_ietf_encrypt(
+        #[\SensitiveParameter]
         $plaintext = '',
         $assocData = '',
         $nonce = '',
+        #[\SensitiveParameter]
         $key = '',
         $dontFallback = false
     ) {
@@ -1191,8 +1226,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_auth($message, $key)
-    {
+    public static function crypto_auth(
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($key, 'string', 2);
@@ -1236,8 +1274,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_auth_verify($mac, $message, $key)
-    {
+    public static function crypto_auth_verify(
+        $mac,
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($mac, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 2);
@@ -1280,8 +1322,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box($plaintext, $nonce, $keypair)
-    {
+    public static function crypto_box(
+        $plaintext,
+        $nonce,
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($plaintext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -1324,8 +1370,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box_seal($plaintext, $publicKey)
-    {
+    public static function crypto_box_seal(
+        #[\SensitiveParameter]
+        $plaintext,
+        $publicKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($plaintext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($publicKey, 'string', 2);
@@ -1362,8 +1411,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_box_seal_open($ciphertext, $keypair)
-    {
+    public static function crypto_box_seal_open(
+        $ciphertext,
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 2);
@@ -1425,8 +1477,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box_keypair_from_secretkey_and_publickey($secretKey, $publicKey)
-    {
+    public static function crypto_box_keypair_from_secretkey_and_publickey(
+        #[\SensitiveParameter]
+        $secretKey,
+        $publicKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($publicKey, 'string', 2);
@@ -1464,8 +1519,12 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_box_open($ciphertext, $nonce, $keypair)
-    {
+    public static function crypto_box_open(
+        $ciphertext,
+        $nonce,
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -1507,8 +1566,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box_publickey($keypair)
-    {
+    public static function crypto_box_publickey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
 
@@ -1538,8 +1599,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box_publickey_from_secretkey($secretKey)
-    {
+    public static function crypto_box_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 1);
 
@@ -1569,8 +1632,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_box_secretkey($keypair)
-    {
+    public static function crypto_box_secretkey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
 
@@ -1601,8 +1666,10 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      * @psalm-suppress UndefinedFunction
      */
-    public static function crypto_box_seed_keypair($seed)
-    {
+    public static function crypto_box_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($seed, 'string', 1);
 
@@ -1631,8 +1698,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_generichash($message, $key = '', $length = self::CRYPTO_GENERICHASH_BYTES)
-    {
+    public static function crypto_generichash(
+        $message,
+        #[\SensitiveParameter]
+        $key = '',
+        $length = self::CRYPTO_GENERICHASH_BYTES
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         if (is_null($key)) {
@@ -1675,8 +1746,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress ReferenceConstraintViolation
      * @psalm-suppress ConflictingReferenceConstraint
      */
-    public static function crypto_generichash_final(&$ctx, $length = self::CRYPTO_GENERICHASH_BYTES)
-    {
+    public static function crypto_generichash_final(
+        #[\SensitiveParameter]
+        &$ctx,
+        $length = self::CRYPTO_GENERICHASH_BYTES
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ctx, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($length, 'int', 2);
@@ -1720,8 +1794,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_generichash_init($key = '', $length = self::CRYPTO_GENERICHASH_BYTES)
-    {
+    public static function crypto_generichash_init(
+        #[\SensitiveParameter]
+        $key = '',
+        $length = self::CRYPTO_GENERICHASH_BYTES
+    ) {
         /* Type checks: */
         if (is_null($key)) {
             $key = '';
@@ -1765,6 +1842,7 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      */
     public static function crypto_generichash_init_salt_personal(
+        #[\SensitiveParameter]
         $key = '',
         $length = self::CRYPTO_GENERICHASH_BYTES,
         $salt = '',
@@ -1811,8 +1889,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedArgument
      * @psalm-suppress ReferenceConstraintViolation
      */
-    public static function crypto_generichash_update(&$ctx, $message)
-    {
+    public static function crypto_generichash_update(
+        #[\SensitiveParameter]
+        &$ctx,
+        $message
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ctx, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 2);
@@ -1855,6 +1936,7 @@ class ParagonIE_Sodium_Compat
         $subkey_len,
         $subkey_id,
         $context,
+        #[\SensitiveParameter]
         $key
     ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($subkey_len, 'int', 1);
@@ -1932,8 +2014,14 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_kx($my_secret, $their_public, $client_public, $server_public, $dontFallback = false)
-    {
+    public static function crypto_kx(
+        #[\SensitiveParameter]
+        $my_secret,
+        $their_public,
+        $client_public,
+        $server_public,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($my_secret, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($their_public, 'string', 2);
@@ -1994,8 +2082,10 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function crypto_kx_seed_keypair($seed)
-    {
+    public static function crypto_kx_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($seed, 'string', 1);
 
         $seed = (string) $seed;
@@ -2026,8 +2116,11 @@ class ParagonIE_Sodium_Compat
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    public static function crypto_kx_client_session_keys($keypair, $serverPublicKey)
-    {
+    public static function crypto_kx_client_session_keys(
+        #[\SensitiveParameter]
+        $keypair,
+        $serverPublicKey
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($serverPublicKey, 'string', 2);
 
@@ -2068,8 +2161,11 @@ class ParagonIE_Sodium_Compat
      * @return array{0: string, 1: string}
      * @throws SodiumException
      */
-    public static function crypto_kx_server_session_keys($keypair, $clientPublicKey)
-    {
+    public static function crypto_kx_server_session_keys(
+        #[\SensitiveParameter]
+        $keypair,
+        $clientPublicKey
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($clientPublicKey, 'string', 2);
 
@@ -2109,8 +2205,10 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function crypto_kx_secretkey($kp)
-    {
+    public static function crypto_kx_secretkey(
+        #[\SensitiveParameter]
+        $kp
+    ) {
         return ParagonIE_Sodium_Core_Util::substr(
             $kp,
             0,
@@ -2144,8 +2242,15 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_pwhash($outlen, $passwd, $salt, $opslimit, $memlimit, $alg = null)
-    {
+    public static function crypto_pwhash(
+        $outlen,
+        #[\SensitiveParameter]
+        $passwd,
+        $salt,
+        $opslimit,
+        $memlimit,
+        $alg = null
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($outlen, 'int', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 2);
         ParagonIE_Sodium_Core_Util::declareScalarType($salt,  'string', 3);
@@ -2196,8 +2301,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_pwhash_str($passwd, $opslimit, $memlimit)
-    {
+    public static function crypto_pwhash_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($opslimit, 'int', 2);
         ParagonIE_Sodium_Core_Util::declareScalarType($memlimit, 'int', 3);
@@ -2223,8 +2332,12 @@ class ParagonIE_Sodium_Compat
      * @return bool
      * @throws SodiumException
      */
-    public static function crypto_pwhash_str_needs_rehash($hash, $opslimit, $memlimit)
-    {
+    public static function crypto_pwhash_str_needs_rehash(
+        #[\SensitiveParameter]
+        $hash,
+        $opslimit,
+        $memlimit
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($hash, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($opslimit, 'int', 2);
         ParagonIE_Sodium_Core_Util::declareScalarType($memlimit, 'int', 3);
@@ -2252,8 +2365,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_pwhash_str_verify($passwd, $hash)
-    {
+    public static function crypto_pwhash_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($hash, 'string', 2);
 
@@ -2279,8 +2396,14 @@ class ParagonIE_Sodium_Compat
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function crypto_pwhash_scryptsalsa208sha256($outlen, $passwd, $salt, $opslimit, $memlimit)
-    {
+    public static function crypto_pwhash_scryptsalsa208sha256(
+        $outlen,
+        #[\SensitiveParameter]
+        $passwd,
+        $salt,
+        $opslimit,
+        $memlimit
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($outlen, 'int', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 2);
         ParagonIE_Sodium_Core_Util::declareScalarType($salt,  'string', 3);
@@ -2339,8 +2462,12 @@ class ParagonIE_Sodium_Compat
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function crypto_pwhash_scryptsalsa208sha256_str($passwd, $opslimit, $memlimit)
-    {
+    public static function crypto_pwhash_scryptsalsa208sha256_str(
+        #[\SensitiveParameter]
+        $passwd,
+        $opslimit,
+        $memlimit
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($opslimit, 'int', 2);
         ParagonIE_Sodium_Core_Util::declareScalarType($memlimit, 'int', 3);
@@ -2373,8 +2500,12 @@ class ParagonIE_Sodium_Compat
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function crypto_pwhash_scryptsalsa208sha256_str_verify($passwd, $hash)
-    {
+    public static function crypto_pwhash_scryptsalsa208sha256_str_verify(
+        #[\SensitiveParameter]
+        $passwd,
+        #[\SensitiveParameter]
+        $hash
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($passwd, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($hash, 'string', 2);
 
@@ -2410,8 +2541,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_scalarmult($secretKey, $publicKey)
-    {
+    public static function crypto_scalarmult(
+        #[\SensitiveParameter]
+        $secretKey,
+        $publicKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($publicKey, 'string', 2);
@@ -2454,8 +2588,10 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress TooFewArguments
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_scalarmult_base($secretKey)
-    {
+    public static function crypto_scalarmult_base(
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 1);
 
@@ -2492,8 +2628,13 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_secretbox($plaintext, $nonce, $key)
-    {
+    public static function crypto_secretbox(
+        #[\SensitiveParameter]
+        $plaintext,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($plaintext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -2532,8 +2673,12 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_secretbox_open($ciphertext, $nonce, $key)
-    {
+    public static function crypto_secretbox_open(
+        $ciphertext,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -2618,8 +2763,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_secretbox_xchacha20poly1305_open($ciphertext, $nonce, $key)
-    {
+    public static function crypto_secretbox_xchacha20poly1305_open(
+        $ciphertext,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($ciphertext, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -2645,8 +2794,10 @@ class ParagonIE_Sodium_Compat
      * @throws Exception
      * @throws SodiumException
      */
-    public static function crypto_secretstream_xchacha20poly1305_init_push($key)
-    {
+    public static function crypto_secretstream_xchacha20poly1305_init_push(
+        #[\SensitiveParameter]
+        $key
+    ) {
         if (PHP_INT_SIZE === 4) {
             return ParagonIE_Sodium_Crypto32::secretstream_xchacha20poly1305_init_push($key);
         }
@@ -2659,8 +2810,11 @@ class ParagonIE_Sodium_Compat
      * @return string Returns a state.
      * @throws Exception
      */
-    public static function crypto_secretstream_xchacha20poly1305_init_pull($header, $key)
-    {
+    public static function crypto_secretstream_xchacha20poly1305_init_pull(
+        $header,
+        #[\SensitiveParameter]
+        $key
+    ) {
         if (ParagonIE_Sodium_Core_Util::strlen($header) < self::CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES) {
             throw new SodiumException(
                 'header size should be SODIUM_CRYPTO_SECRETSTREAM_XCHACHA20POLY1305_HEADERBYTES bytes'
@@ -2680,8 +2834,14 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function crypto_secretstream_xchacha20poly1305_push(&$state, $msg, $aad = '', $tag = 0)
-    {
+    public static function crypto_secretstream_xchacha20poly1305_push(
+        #[\SensitiveParameter]
+        &$state,
+        #[\SensitiveParameter]
+        $msg,
+        $aad = '',
+        $tag = 0
+    ) {
         if (PHP_INT_SIZE === 4) {
             return ParagonIE_Sodium_Crypto32::secretstream_xchacha20poly1305_push(
                 $state,
@@ -2705,8 +2865,12 @@ class ParagonIE_Sodium_Compat
      * @return bool|array{0: string, 1: int}
      * @throws SodiumException
      */
-    public static function crypto_secretstream_xchacha20poly1305_pull(&$state, $msg, $aad = '')
-    {
+    public static function crypto_secretstream_xchacha20poly1305_pull(
+        #[\SensitiveParameter]
+        &$state,
+        $msg,
+        $aad = ''
+    ) {
         if (PHP_INT_SIZE === 4) {
             return ParagonIE_Sodium_Crypto32::secretstream_xchacha20poly1305_pull(
                 $state,
@@ -2735,8 +2899,10 @@ class ParagonIE_Sodium_Compat
      * @return void
      * @throws SodiumException
      */
-    public static function crypto_secretstream_xchacha20poly1305_rekey(&$state)
-    {
+    public static function crypto_secretstream_xchacha20poly1305_rekey(
+        #[\SensitiveParameter]
+        &$state
+    ) {
         if (PHP_INT_SIZE === 4) {
             ParagonIE_Sodium_Crypto32::secretstream_xchacha20poly1305_rekey($state);
         } else {
@@ -2756,8 +2922,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_shorthash($message, $key)
-    {
+    public static function crypto_shorthash(
+        $message,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($key, 'string', 2);
@@ -2806,8 +2975,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_sign($message, $secretKey)
-    {
+    public static function crypto_sign(
+        $message,
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 2);
@@ -2842,8 +3014,10 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress MixedInferredReturnType
      * @psalm-suppress MixedReturnStatement
      */
-    public static function crypto_sign_open($signedMessage, $publicKey)
-    {
+    public static function crypto_sign_open(
+        $signedMessage,
+        $publicKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($signedMessage, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($publicKey, 'string', 2);
@@ -2899,8 +3073,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function crypto_sign_keypair_from_secretkey_and_publickey($sk, $pk)
-    {
+    public static function crypto_sign_keypair_from_secretkey_and_publickey(
+        #[\SensitiveParameter]
+        $sk,
+        $pk
+    )  {
         ParagonIE_Sodium_Core_Util::declareScalarType($sk, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($pk, 'string', 1);
         $sk = (string) $sk;
@@ -2928,8 +3105,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_seed_keypair($seed)
-    {
+    public static function crypto_sign_seed_keypair(
+        #[\SensitiveParameter]
+        $seed
+    ) {
         ParagonIE_Sodium_Core_Util::declareScalarType($seed, 'string', 1);
 
         if (self::useNewSodiumAPI()) {
@@ -2957,8 +3136,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_publickey($keypair)
-    {
+    public static function crypto_sign_publickey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
 
@@ -2988,8 +3169,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_publickey_from_secretkey($secretKey)
-    {
+    public static function crypto_sign_publickey_from_secretkey(
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 1);
 
@@ -3019,8 +3202,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_secretkey($keypair)
-    {
+    public static function crypto_sign_secretkey(
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($keypair, 'string', 1);
 
@@ -3053,8 +3238,11 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_detached($message, $secretKey)
-    {
+    public static function crypto_sign_detached(
+        $message,
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($secretKey, 'string', 2);
@@ -3161,8 +3349,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_sign_ed25519_sk_to_curve25519($sk)
-    {
+    public static function crypto_sign_ed25519_sk_to_curve25519(
+        #[\SensitiveParameter]
+        $sk
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($sk, 'string', 1);
 
@@ -3203,8 +3393,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_stream($len, $nonce, $key)
-    {
+    public static function crypto_stream(
+        $len,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($len, 'int', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -3250,8 +3444,13 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_stream_xor($message, $nonce, $key)
-    {
+    public static function crypto_stream_xor(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -3305,8 +3504,13 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_stream_xchacha20($len, $nonce, $key, $dontFallback = false)
-    {
+    public static function crypto_stream_xchacha20(
+        $len,
+        $nonce,
+        #[\SensitiveParameter]
+        $key,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($len, 'int', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -3350,8 +3554,14 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_stream_xchacha20_xor($message, $nonce, $key, $dontFallback = false)
-    {
+    public static function crypto_stream_xchacha20_xor(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        #[\SensitiveParameter]
+        $key,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -3396,8 +3606,15 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function crypto_stream_xchacha20_xor_ic($message, $nonce, $counter, $key, $dontFallback = false)
-    {
+    public static function crypto_stream_xchacha20_xor_ic(
+        #[\SensitiveParameter]
+        $message,
+        $nonce,
+        $counter,
+        #[\SensitiveParameter]
+        $key,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($message, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($nonce, 'string', 2);
@@ -3446,8 +3663,11 @@ class ParagonIE_Sodium_Compat
      * @psalm-suppress TooFewArguments
      * @psalm-suppress MixedArgument
      */
-    public static function hex2bin($string, $ignore = '')
-    {
+    public static function hex2bin(
+        #[\SensitiveParameter]
+        $string,
+        $ignore = ''
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($string, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($ignore, 'string', 2);
@@ -3473,8 +3693,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function increment(&$var)
-    {
+    public static function increment(
+        #[\SensitiveParameter]
+        &$var
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($var, 'string', 1);
 
@@ -3507,8 +3729,10 @@ class ParagonIE_Sodium_Compat
      *
      * @throws SodiumException
      */
-    public static function is_zero($str)
-    {
+    public static function is_zero(
+        #[\SensitiveParameter]
+        $str
+    ) {
         $d = 0;
         for ($i = 0; $i < 32; ++$i) {
             $d |= ParagonIE_Sodium_Core_Util::chrToInt($str[$i]);
@@ -3562,8 +3786,12 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress MixedArgument
      */
-    public static function memcmp($left, $right)
-    {
+    public static function memcmp(
+        #[\SensitiveParameter]
+        $left,
+        #[\SensitiveParameter]
+        $right
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($left, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($right, 'string', 2);
@@ -3591,8 +3819,10 @@ class ParagonIE_Sodium_Compat
      * @throws TypeError
      * @psalm-suppress TooFewArguments
      */
-    public static function memzero(&$var)
-    {
+    public static function memzero(
+        #[\SensitiveParameter]
+        &$var
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($var, 'string', 1);
 
@@ -3622,8 +3852,12 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function pad($unpadded, $blockSize, $dontFallback = false)
-    {
+    public static function pad(
+        #[\SensitiveParameter]
+        $unpadded,
+        $blockSize,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($unpadded, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($blockSize, 'int', 2);
@@ -3708,8 +3942,12 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function unpad($padded, $blockSize, $dontFallback = false)
-    {
+    public static function unpad(
+        #[\SensitiveParameter]
+        $padded,
+        $blockSize,
+        $dontFallback = false
+    ) {
         /* Type checks: */
         ParagonIE_Sodium_Core_Util::declareScalarType($padded, 'string', 1);
         ParagonIE_Sodium_Core_Util::declareScalarType($blockSize, 'int', 2);
@@ -3863,8 +4101,11 @@ class ParagonIE_Sodium_Compat
      * @return bool
      * @throws SodiumException
      */
-    public static function ristretto255_is_valid_point($p, $dontFallback = false)
-    {
+    public static function ristretto255_is_valid_point(
+        #[\SensitiveParameter]
+        $p,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_is_valid_point($p);
         }
@@ -3887,8 +4128,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_add($p, $q, $dontFallback = false)
-    {
+    public static function ristretto255_add(
+        #[\SensitiveParameter]
+        $p,
+        #[\SensitiveParameter]
+        $q,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_add($p, $q);
         }
@@ -3902,8 +4148,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_sub($p, $q, $dontFallback = false)
-    {
+    public static function ristretto255_sub(
+        #[\SensitiveParameter]
+        $p,
+        #[\SensitiveParameter]
+        $q,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_sub($p, $q);
         }
@@ -3917,8 +4168,11 @@ class ParagonIE_Sodium_Compat
      *
      * @throws SodiumException
      */
-    public static function ristretto255_from_hash($r, $dontFallback = false)
-    {
+    public static function ristretto255_from_hash(
+        #[\SensitiveParameter]
+        $r,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_from_hash($r);
         }
@@ -3959,8 +4213,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_invert($s, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_invert(
+        #[\SensitiveParameter]
+        $s,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_invert($s);
         }
@@ -3972,8 +4229,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_negate($s, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_negate(
+        #[\SensitiveParameter]
+        $s,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_negate($s);
         }
@@ -3986,8 +4246,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_complement($s, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_complement(
+        #[\SensitiveParameter]
+        $s,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_complement($s);
         }
@@ -4001,8 +4264,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_add($x, $y, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_add(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_add($x, $y);
         }
@@ -4016,8 +4284,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_sub($x, $y, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_sub(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_sub($x, $y);
         }
@@ -4031,8 +4304,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_mul($x, $y, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_mul(
+        #[\SensitiveParameter]
+        $x,
+        #[\SensitiveParameter]
+        $y,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_mul($x, $y);
         }
@@ -4046,8 +4324,13 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function scalarmult_ristretto255($n, $p, $dontFallback = false)
-    {
+    public static function scalarmult_ristretto255(
+        #[\SensitiveParameter]
+        $n,
+        #[\SensitiveParameter]
+        $p,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_scalarmult_ristretto255($n, $p);
         }
@@ -4061,8 +4344,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function scalarmult_ristretto255_base($n, $dontFallback = false)
-    {
+    public static function scalarmult_ristretto255_base(
+        #[\SensitiveParameter]
+        $n,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_scalarmult_ristretto255_base($n);
         }
@@ -4075,8 +4361,11 @@ class ParagonIE_Sodium_Compat
      * @return string
      * @throws SodiumException
      */
-    public static function ristretto255_scalar_reduce($s, $dontFallback = false)
-    {
+    public static function ristretto255_scalar_reduce(
+        #[\SensitiveParameter]
+        $s,
+        $dontFallback = false
+    ) {
         if (self::useNewSodiumAPI() && !$dontFallback) {
             return sodium_crypto_core_ristretto255_scalar_reduce($s);
         }
@@ -4130,8 +4419,12 @@ class ParagonIE_Sodium_Compat
      * @return void
      * @throws SodiumException
      */
-    public static function sub(&$val, $addv)
-    {
+    public static function sub(
+        #[\SensitiveParameter]
+        &$val,
+        #[\SensitiveParameter]
+        $addv
+    ) {
         $val_len = ParagonIE_Sodium_Core_Util::strlen($val);
         $addv_len = ParagonIE_Sodium_Core_Util::strlen($addv);
         if ($val_len !== $addv_len) {

--- a/src/File.php
+++ b/src/File.php
@@ -25,8 +25,13 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function box($inputFile, $outputFile, $nonce, $keyPair)
-    {
+    public static function box(
+        $inputFile,
+        $outputFile,
+        $nonce,
+        #[\SensitiveParameter]
+        $keyPair
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given.');
@@ -91,8 +96,13 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function box_open($inputFile, $outputFile, $nonce, $keypair)
-    {
+    public static function box_open(
+        $inputFile,
+        $outputFile,
+        $nonce,
+        #[\SensitiveParameter]
+        $keypair
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given.');
@@ -161,8 +171,12 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function box_seal($inputFile, $outputFile, $publicKey)
-    {
+    public static function box_seal(
+        $inputFile,
+        $outputFile,
+        #[\SensitiveParameter]
+        $publicKey
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given.');
@@ -265,8 +279,12 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function box_seal_open($inputFile, $outputFile, $ecdhKeypair)
-    {
+    public static function box_seal_open(
+        $inputFile,
+        $outputFile,
+        #[\SensitiveParameter]
+        $ecdhKeypair
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given.');
@@ -350,8 +368,12 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws TypeError
      * @psalm-suppress FailedTypeResolution
      */
-    public static function generichash($filePath, $key = '', $outputLength = 32)
-    {
+    public static function generichash(
+        $filePath,
+        #[\SensitiveParameter]
+        $key = '',
+        $outputLength = 32
+    ) {
         /* Type checks: */
         if (!is_string($filePath)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($filePath) . ' given.');
@@ -428,8 +450,13 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function secretbox($inputFile, $outputFile, $nonce, $key)
-    {
+    public static function secretbox(
+        $inputFile,
+        $outputFile,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given..');
@@ -493,8 +520,13 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function secretbox_open($inputFile, $outputFile, $nonce, $key)
-    {
+    public static function secretbox_open(
+        $inputFile,
+        $outputFile,
+        $nonce,
+        #[\SensitiveParameter]
+        $key
+    ) {
         /* Type checks: */
         if (!is_string($inputFile)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($inputFile) . ' given.');
@@ -560,8 +592,11 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws SodiumException
      * @throws TypeError
      */
-    public static function sign($filePath, $secretKey)
-    {
+    public static function sign(
+        $filePath,
+        #[\SensitiveParameter]
+        $secretKey
+    ) {
         /* Type checks: */
         if (!is_string($filePath)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($filePath) . ' given.');
@@ -656,8 +691,11 @@ class ParagonIE_Sodium_File extends ParagonIE_Sodium_Core_Util
      * @throws TypeError
      * @throws Exception
      */
-    public static function verify($sig, $filePath, $publicKey)
-    {
+    public static function verify(
+        $sig,
+        $filePath,
+        $publicKey
+    ) {
         /* Type checks: */
         if (!is_string($sig)) {
             throw new TypeError('Argument 1 must be a string, ' . gettype($sig) . ' given.');


### PR DESCRIPTION
In PHP 8.2 and newer, this attribute is used to mark parameters that are sensitive and should be redacted from stack traces.

This has no effect on PHP 8.1 or older, but is a nice-to-have for PHP 8.2+.