### PR TITLE
Make composer aware of the requirement for 64bits PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "files": ["autoload.php"]
   },
   "require": {
-    "php": "^8.1"
+    "php": "^8.1",
+    "php-64bit": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^7|^8|^9",


### PR DESCRIPTION
this way, when running on a 32bits version of PHP, Composer will know it cannot use those releases (too bad this was not done in the 2.0.0 release)