### PR TITLE
explicitly mark argument $alg as nullable

### DIFF
--- a/src/Compat.php
+++ b/src/Compat.php
@@ -1863,7 +1863,7 @@ class ParagonIE_Sodium_Compat
         string $salt,
         int $opslimit,
         int $memlimit,
-        int $alg = null
+        ?int $alg = null
     ): string {
         if (self::useNewSodiumAPI()) {
             if (!is_null($alg)) {


### PR DESCRIPTION
Implicitly marking it as nullable is deprecated starting with PHP 8.4.