### PR TITLE
GH Actions: update the actions/checkout action runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
The v3 version still uses Node 16, while GHA will stop supporting that soonish. Using v4 fixes that.