### PR TITLE
Remove dead or redundant code of `Util::(strlen|substr)`

### DIFF
--- a/src/Core/Util.php
+++ b/src/Core/Util.php
@@ -509,8 +509,6 @@ abstract class ParagonIE_Sodium_Core_Util
      *
      * @internal You should not use this directly from another application
      *
-     * @ref mbstring.func_overload
-     *
      * @param string $str
      * @return int
      * @throws TypeError
@@ -519,11 +517,7 @@ abstract class ParagonIE_Sodium_Core_Util
         #[SensitiveParameter]
         string $str
     ): int {
-        return (
-        self::isMbStringOverride()
-            ? mb_strlen($str, '8bit')
-            : strlen($str)
-        );
+        return strlen($str);
     }
 
     /**
@@ -547,8 +541,6 @@ abstract class ParagonIE_Sodium_Core_Util
      *
      * @internal You should not use this directly from another application
      *
-     * @ref mbstring.func_overload
-     *
      * @param string $str
      * @param int $start
      * @param ?int $length
@@ -565,20 +557,7 @@ abstract class ParagonIE_Sodium_Core_Util
             return '';
         }
 
-        if (self::isMbStringOverride()) {
-            if (PHP_VERSION_ID < 50400 && $length === null) {
-                $length = self::strlen($str);
-            }
-            $sub = mb_substr($str, $start, $length, '8bit');
-        } elseif ($length === null) {
-            $sub = substr($str, $start);
-        } else {
-            $sub = substr($str, $start, $length);
-        }
-        if ($sub !== '') {
-            return $sub;
-        }
-        return '';
+        return substr($str, $start, $length);
     }
 
     /**
@@ -646,33 +625,4 @@ abstract class ParagonIE_Sodium_Core_Util
         return $a ^ $b;
     }
 
-    /**
-     * Returns whether or not mbstring.func_overload is in effect.
-     *
-     * @internal You should not use this directly from another application
-     *
-     * Note: MB_OVERLOAD_STRING === 2, but we don't reference the constant
-     * (for nuisance-free PHP 8 support)
-     *
-     * @return bool
-     */
-    protected static function isMbStringOverride(): bool
-    {
-        static $mbstring = null;
-
-        if ($mbstring === null) {
-            if (!defined('MB_OVERLOAD_STRING')) {
-                $mbstring = false;
-                return $mbstring;
-            }
-            $mbstring = extension_loaded('mbstring')
-                && defined('MB_OVERLOAD_STRING')
-                &&
-            ((int) (ini_get('mbstring.func_overload')) & 2);
-            // MB_OVERLOAD_STRING === 2
-        }
-        /** @var bool $mbstring */
-
-        return $mbstring;
-    }
 }

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -225,12 +225,13 @@ class UtilTest extends TestCase
     public function testSubstr(): void
     {
         $string = str_repeat("\xF0\x9D\x92\xB3", 4);
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 0, 1), "\xF0");
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 1, 1), "\x9D");
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 2, 1), "\x92");
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 3, 1), "\xB3");
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 0, 2), "\xF0\x9D");
-        $this->assertSame(ParagonIE_Sodium_Core_Util::substr($string, 2, 2), "\x92\xB3");
+        $this->assertSame("\xF0", ParagonIE_Sodium_Core_Util::substr($string, 0, 1));
+        $this->assertSame("\x9D", ParagonIE_Sodium_Core_Util::substr($string, 1, 1));
+        $this->assertSame("\x92", ParagonIE_Sodium_Core_Util::substr($string, 2, 1));
+        $this->assertSame("\xB3", ParagonIE_Sodium_Core_Util::substr($string, 3, 1));
+        $this->assertSame("\xF0\x9D", ParagonIE_Sodium_Core_Util::substr($string, 0, 2));
+        $this->assertSame("\x92\xB3", ParagonIE_Sodium_Core_Util::substr($string, 2, 2));
+        $this->assertSame("\x9D\x92\xB3", ParagonIE_Sodium_Core_Util::substr($string, 13));
     }
 
     public function testStore64(): void


### PR DESCRIPTION
Since sodium_compat v2 requires PHP 8.1+, we can remove some codes.

- Function overload feature of mbstring was removed as of PHP 8.0.
- Starting from PHP 8.0, `substr($str, $offset, null)` has same effect as `substr($str, $offset)`.

Also adding a test case of omitting the third parameter of `substr`.